### PR TITLE
Fix matcha detection for secondary keywords

### DIFF
--- a/matcha-finder-share/verify_matcha.py
+++ b/matcha-finder-share/verify_matcha.py
@@ -17,7 +17,7 @@ def _has_matcha_text(text: str)->bool:
         # ネガが強く出るなら様子見
         pass
     # セカンダリ語彙は“matcha”不在時のみ弱判定
-    if any(re.search(p, t, re.I) for p in KW_SECONDARY) and "matcha" in t.lower():
+    if any(re.search(p, t, re.I) for p in KW_SECONDARY) and "matcha" not in t.lower():
         return True
     return False
 

--- a/test_verify_matcha.py
+++ b/test_verify_matcha.py
@@ -1,0 +1,14 @@
+from verify_matcha import _has_matcha_text
+
+
+def test_direct_matcha_word():
+    assert _has_matcha_text("Try our Matcha latte today!")
+
+
+def test_secondary_keyword_without_matcha():
+    text = "We serve ceremonial green tea desserts"
+    assert _has_matcha_text(text)
+
+
+def test_negative_word_only():
+    assert not _has_matcha_text("Houjicha and sencha available")

--- a/verify_matcha.py
+++ b/verify_matcha.py
@@ -17,7 +17,7 @@ def _has_matcha_text(text: str)->bool:
         # ネガが強く出るなら様子見
         pass
     # セカンダリ語彙は“matcha”不在時のみ弱判定
-    if any(re.search(p, t, re.I) for p in KW_SECONDARY) and "matcha" in t.lower():
+    if any(re.search(p, t, re.I) for p in KW_SECONDARY) and "matcha" not in t.lower():
         return True
     return False
 


### PR DESCRIPTION
## Summary
- Correct matcha keyword logic to trigger on secondary terms when "matcha" text absent
- Add regression tests ensuring detection of secondary keywords

## Testing
- `pytest test_verify_matcha.py -q`
- `pytest -q` *(fails: FileNotFoundError: No such file or directory: 'service_account.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a9dc840300832281340c2dbe15f907