### PR TITLE
Handle relative canonical URLs and skip generic paths in _to_home

### DIFF
--- a/name_utils.py
+++ b/name_utils.py
@@ -117,13 +117,16 @@ def _to_home(url, html=None):
     """/menu 等を受け取ってもホームへ寄せる（canonical 優先）"""
     try:
         u = urlparse(url)
+        base = f"{u.scheme}://{u.netloc}/"
         if html:
             soup = BeautifulSoup(html, "lxml")
             can = soup.find("link", rel=lambda x: x and "canonical" in x)
             if can and can.get("href"):
-                c = can["href"].strip()
-                if c.startswith("http"): return c
-        return f"{u.scheme}://{u.netloc}/"
+                c = urljoin(url, can["href"].strip())
+                can_path = urlparse(c).path.lower()
+                if not any(can_path.startswith(p) for p in GENERIC_PAGES):
+                    return c
+        return base
     except Exception:
         return url
 


### PR DESCRIPTION
## Summary
- Fix `_to_home` to resolve relative canonical links and ignore generic pages such as `/privacy`

## Testing
- `pytest -q` *(fails: FileNotFoundError: 'service_account.json')*


------
https://chatgpt.com/codex/tasks/task_e_68a9cfdc8c0c8322a96e0e5d4f271ae5