### PR TITLE
Warn when SKIP_SHEETS is set and ensure Actions write to Sheets

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -21,4 +21,5 @@ jobs:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           GOOGLE_CX: ${{ secrets.GOOGLE_CX }}
           SHEET_ID: ${{ secrets.SHEET_ID }}
+          SKIP_SHEETS: "0"
         run: python pipeline.py

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ jobs:
       SHEET_ID: ${{ secrets.SHEET_ID }}
       TARGET_NEW: ${{ github.event.inputs.target_new }}
       DEBUG: "1"                      # 詳細ログ（不要なら消してOK）
+      SKIP_SHEETS: "0"
     steps:
       - uses: actions/checkout@v4
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -358,6 +358,9 @@ def handle_candidate(src_url, existing_urls, newly_added_urls, out_rows):
     return True
 def main():
     load_dotenv()
+    skip_env = _os.getenv("SKIP_SHEETS", "").lower()
+    if skip_env in ("1", "true", "yes", "on"):
+        logging.warning("SKIP_SHEETS=%s -> sheet append disabled", skip_env)
     ws = open_sheet()
     existing_urls = get_existing_official_urls(ws)
     newly_added_urls = set()

--- a/run_trace.py
+++ b/run_trace.py
@@ -21,6 +21,11 @@ if not diag_logger.handlers:
     diag_logger.addHandler(fh)
 log = diag_logger
 
+# SKIP_SHEETS が指定されている場合は早めに通知
+_skip_env = os.getenv("SKIP_SHEETS", "").lower()
+if _skip_env in ("1", "true", "yes", "on"):
+    log.warning("[trace] SKIP_SHEETS=%s -> Sheets append disabled", _skip_env)
+
 # ---- ネットワーク既定タイムアウト（requests を含む全体）----
 socket.setdefaulttimeout(int(os.getenv("SOCKET_TIMEOUT","20")))
 try:
@@ -105,7 +110,7 @@ def apply_wrappers():
         if hasattr(sio, "append_rows_batched"):
             _orig_append = sio.append_rows_batched
             APP_T = int(os.getenv("APPEND_TIMEOUT","45"))
-            SKIP  = os.getenv("SKIP_SHEETS","0") == "1"
+            SKIP  = _skip_env in ("1", "true", "yes", "on")
 
             def _wrap_append(rows, *a, **kw):
                 try: n = len(rows)


### PR DESCRIPTION
## Summary
- Log explicit warning when `SKIP_SHEETS` disables sheet updates
- Propagate `SKIP_SHEETS=0` in workflows so Actions write results to Google Sheets

## Testing
- `pytest -q` *(fails: FileNotFoundError: 'service_account.json')*

------
https://chatgpt.com/codex/tasks/task_e_68aa903958208322a9cc0755e7b95b4b