### PR TITLE
Warn when SKIP_SHEETS is set and fix sheet append in pipeline

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -21,4 +21,5 @@ jobs:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           GOOGLE_CX: ${{ secrets.GOOGLE_CX }}
           SHEET_ID: ${{ secrets.SHEET_ID }}
+          SKIP_SHEETS: "0"
         run: python pipeline.py

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ jobs:
       SHEET_ID: ${{ secrets.SHEET_ID }}
       TARGET_NEW: ${{ github.event.inputs.target_new }}
       DEBUG: "1"                      # 詳細ログ（不要なら消してOK）
+      SKIP_SHEETS: "0"
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Log explicit warning when `SKIP_SHEETS` disables sheet updates
- Propagate `SKIP_SHEETS=0` in workflows so Actions attempt to update the spreadsheet
- Import `append_rows_batched` in `pipeline` and correct tracing wrapper so rows actually write to Sheets

## Testing
- `pytest -q` *(fails: FileNotFoundError: 'service_account.json')*

------
https://chatgpt.com/codex/tasks/task_e_68aa903958208322a9cc0755e7b95b4b