### PR TITLE
Add entrypoint guard to pipeline_smart

### DIFF
--- a/pipeline_smart.py
+++ b/pipeline_smart.py
@@ -201,3 +201,6 @@ def main():
 
     save_json(SEEN_PATH, {"roots": sorted(seen_roots)})
     print(f"[END] 追加 {added} 件で終了")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a main entrypoint guard to `pipeline_smart.py`

## Testing
- `python -m py_compile pipeline_smart.py`
- `pytest` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'service_account.json')*
- `act -j run -W .github/workflows/main.yml` *(fails: command not found: act)*

------
https://chatgpt.com/codex/tasks/task_e_68aa9be1e8cc832290c035c8ab64f751