### PR TITLE
Improve cafe snippet filtering and block aggregator domains

### DIFF
--- a/light_extract.py
+++ b/light_extract.py
@@ -13,7 +13,8 @@ BLOCK_DOMAINS = {
     "opentable.com","resy.com","sevenrooms.com","tripadvisor.com","pinterest.com",
     "facebook.com","m.facebook.com","instagram.com","tiktok.com","reddit.com","vogue.com",
     "theinfatuation.com","eater.com","la.eater.com","ny.eater.com","toasttab.com","square.site",
-    "linktr.ee","google.com","maps.google.com","order.online","order.alfred.la"
+    "linktr.ee","google.com","maps.google.com","order.online","order.alfred.la",
+    "vivinavi.com","vividnavigation.com"
 }
 
 MATCHA_WORDS = re.compile(r'(matcha|抹茶|green\s*tea\s*latte|ceremonial\s*matcha|iced\s*matcha|dirty\s*matcha)', re.I)

--- a/pipeline_smart.py
+++ b/pipeline_smart.py
@@ -12,6 +12,12 @@ load_dotenv()
 
 SEEN_PATH = ".seen_roots.json"  # 既に検証したルートを保存（同じ結果の再検証を避ける）
 
+# スニペット判定用（ベーカリー単独は除外）
+SNIPPET_CAFE_HINTS = re.compile(
+    r"\b(cafe|coffee|tea|teahouse|boba|bubble\s*tea)\b|カフェ|コーヒー|珈琲|喫茶",
+    re.I,
+)
+
 def load_json(path, default):
     if os.path.exists(path):
         try:
@@ -25,10 +31,11 @@ def save_json(path, obj):
     except Exception: pass
 
 def snippet_ok(item, home: str) -> bool:
-    # スニペットに matcha / 抹茶 があるなら即OK（ただしメディア/プラットフォームは除外）
+    # スニペットに matcha / 抹茶 があり、かつカフェ系ワードを含む場合のみ採用
     title = (item.get("title") or "") + " " + (item.get("snippet") or "")
-    if is_media_or_platform(home): return False
-    return bool(MATCHA_WORDS.search(title))
+    if is_media_or_platform(home):
+        return False
+    return bool(MATCHA_WORDS.search(title) and SNIPPET_CAFE_HINTS.search(title))
 
 def mini_site_matcha(cse: CSEClient, home: str) -> bool:
     # サイト内簡易検索（site:host matcha）で補強。予算が少ないので最大1クエリのみ。


### PR DESCRIPTION
## Summary
- Require cafe-related terms in search snippets to reduce non-cafe hits
- Block Vivinavi directory domains when normalizing URLs

## Testing
- `pytest -q` *(fails: FileNotFoundError: 'service_account.json')*

------
https://chatgpt.com/codex/tasks/task_e_68aa9f9026bc8322ab646ee77de53b37