### PR TITLE
Add wide search pre-pass with pagination

### DIFF
--- a/pipeline_smart.py
+++ b/pipeline_smart.py
@@ -7,6 +7,7 @@ from light_extract import (
     is_blocked, normalize_candidate_url, find_menu_links, one_pdf_text_from,
     extract_contacts, is_us_cafe_site, guess_brand, MATCHA_WORDS
 )
+from search_google import search_candidates_iter
 
 load_dotenv()
 
@@ -100,27 +101,17 @@ def main():
     seen = load_json(SEEN_PATH, {"roots": []})
     seen_roots = set(seen.get("roots", []))
 
-    queries = default_queries()
     added = 0
     cse = CSEClient(api_key, cx, max_daily=int(os.getenv("MAX_DAILY_CSE_QUERIES","100")))
     max_queries = int(os.getenv("MAX_QUERIES_PER_RUN", "50"))
 
-    for idx, q in enumerate(queries):
-        if idx >= max_queries:
-            if debug:
-                print("[STOP] per-run query cap reached")
-            break
-        try:
-            data = cse.search(q, start=1, num=10, safe="off", lr="lang_en", cr="countryUS")
-        except DailyQuotaExceeded:
-            print("[STOP] Google CSE 日次上限/レート制限に到達。")
-            break
-        except Exception as e:
-            if debug: print(f"search error: {e}")
-            continue
-
-        for it in (data.get("items") or []):
-            raw = (it.get("link") or "").strip()
+    # まず広域クエリをページ巡回しながら収集
+    wide_q = os.getenv(
+        "WIDE_QUERY",
+        "matcha cafe -yelp -ubereats -doordash -tripadvisor -opentable -facebook -linktr.ee",
+    )
+    try:
+        for raw in search_candidates_iter(wide_q, num=10, start=1, max_pages=3):
             home = normalize_candidate_url(raw)
             if not home:
                 if debug: print(f"skip[{raw}]: blocked or empty")
@@ -131,14 +122,12 @@ def main():
             if home in seen_homes:
                 if debug: print(f"skip[{home}]: already-in-sheet")
                 continue
-
-            # 1) スニペット事前判定（US向け/プラットフォーム除外）
-            if not snippet_ok(it, home):
-                if debug: print(f"skip[{home}]: snippet not matcha or platform")
+            if is_media_or_platform(home):
+                if debug: print(f"skip[{home}]: platform or media")
                 seen_roots.add(home)
                 continue
 
-            # 2) ランディング取得
+            # ランディング取得
             r = http_get(home)
             html = r.text if (r and r.text) else ""
             if not html:
@@ -146,7 +135,7 @@ def main():
                 seen_roots.add(home)
                 continue
 
-            # 3) マッチャ証拠：本文/メニュー/PDF or サイト内ミニ検索
+            # マッチャ証拠：本文/メニュー/PDF or サイト内ミニ検索
             ok = bool(MATCHA_WORDS.search(html_text(html)))
             if not ok:
                 for m in find_menu_links(html, home, limit=3):
@@ -165,27 +154,27 @@ def main():
                 seen_roots.add(home)
                 continue
 
-            # 4) US の独立カフェらしさ
+            # US の独立カフェらしさ
             if not is_us_cafe_site(home, html):
                 if debug: print(f"skip[{home}]: not US independent cafe")
                 seen_roots.add(home)
                 continue
 
-            # 5) 連絡先抽出（必須）
+            # 連絡先抽出（必須）
             ig, emails, form = extract_contacts(home, html)
             if require_contact_on_snippet and not (ig or emails or form):
                 if debug: print(f"skip[{home}]: no contacts found")
                 seen_roots.add(home)
                 continue
 
-            # 6) IG 重複／シート重複チェック
+            # IG 重複／シート重複チェック
             ig_key = canon_url(ig) if ig else ""
             if ig_key and ig_key in seen_instas:
                 if debug: print(f"skip[{home}]: dup insta")
                 seen_roots.add(home)
                 continue
 
-            brand = guess_brand(home, html, it.get("title") or "")
+            brand = guess_brand(home, html, "")
             row = {
                 "店名": brand,
                 "国": "US",
@@ -210,6 +199,117 @@ def main():
                 print(f"[WARN] スプシ書き込み失敗: {home} -> {e}")
                 traceback.print_exc()
                 seen_roots.add(home)
+    except Exception as e:
+        if debug: print(f"search_iter error: {e}")
+
+    # 広域クエリで30件未満なら州別クエリで補完
+    if added < 30:
+        queries = default_queries()
+        for idx, q in enumerate(queries):
+            if idx >= max_queries:
+                if debug:
+                    print("[STOP] per-run query cap reached")
+                break
+            try:
+                data = cse.search(q, start=1, num=10, safe="off", lr="lang_en", cr="countryUS")
+            except DailyQuotaExceeded:
+                print("[STOP] Google CSE 日次上限/レート制限に到達。")
+                break
+            except Exception as e:
+                if debug: print(f"search error: {e}")
+                continue
+
+            for it in (data.get("items") or []):
+                raw = (it.get("link") or "").strip()
+                home = normalize_candidate_url(raw)
+                if not home:
+                    if debug: print(f"skip[{raw}]: blocked or empty")
+                    continue
+                if home in seen_roots:
+                    if debug: print(f"skip[{home}]: already-seen root")
+                    continue
+                if home in seen_homes:
+                    if debug: print(f"skip[{home}]: already-in-sheet")
+                    continue
+
+                # 1) スニペット事前判定（US向け/プラットフォーム除外）
+                if not snippet_ok(it, home):
+                    if debug: print(f"skip[{home}]: snippet not matcha or platform")
+                    seen_roots.add(home)
+                    continue
+
+                # 2) ランディング取得
+                r = http_get(home)
+                html = r.text if (r and r.text) else ""
+                if not html:
+                    if debug: print(f"skip[{home}]: no html")
+                    seen_roots.add(home)
+                    continue
+
+                # 3) マッチャ証拠：本文/メニュー/PDF or サイト内ミニ検索
+                ok = bool(MATCHA_WORDS.search(html_text(html)))
+                if not ok:
+                    for m in find_menu_links(html, home, limit=3):
+                        r2 = http_get(m)
+                        if r2 and r2.text and MATCHA_WORDS.search(html_text(r2.text)):
+                            ok = True; break
+                if not ok:
+                    pdf_text = one_pdf_text_from(html, home)
+                    if pdf_text and MATCHA_WORDS.search(pdf_text.lower()):
+                        ok = True
+                if not ok:
+                    ok = mini_site_matcha(cse, home)
+
+                if not ok:
+                    if debug: print(f"skip[{home}]: no matcha evidence (html+menu+pdf+site)")
+                    seen_roots.add(home)
+                    continue
+
+                # 4) US の独立カフェらしさ
+                if not is_us_cafe_site(home, html):
+                    if debug: print(f"skip[{home}]: not US independent cafe")
+                    seen_roots.add(home)
+                    continue
+
+                # 5) 連絡先抽出（必須）
+                ig, emails, form = extract_contacts(home, html)
+                if require_contact_on_snippet and not (ig or emails or form):
+                    if debug: print(f"skip[{home}]: no contacts found")
+                    seen_roots.add(home)
+                    continue
+
+                # 6) IG 重複／シート重複チェック
+                ig_key = canon_url(ig) if ig else ""
+                if ig_key and ig_key in seen_instas:
+                    if debug: print(f"skip[{home}]: dup insta")
+                    seen_roots.add(home)
+                    continue
+
+                brand = guess_brand(home, html, it.get("title") or "")
+                row = {
+                    "店名": brand,
+                    "国": "US",
+                    "公式サイトURL": home,
+                    "Instagramリンク": ig,
+                    "問い合わせアドレス": (emails[0] if emails else ""),
+                    "問い合わせフォームURL": form
+                }
+
+                try:
+                    append_row_in_order(sheet_id, ws_name, row)
+                    added += 1
+                    seen_homes.add(home)
+                    if ig_key: seen_instas.add(ig_key)
+                    seen_roots.add(home)
+                    print(f"[ADD] {brand} -> {home} contacts: ig={ig or '-'} email={(emails[0] if emails else '-')} form={form or '-'} （累計 {added}）")
+                    if added >= target:
+                        save_json(SEEN_PATH, {"roots": sorted(seen_roots)})
+                        print("[DONE] 目標件数に到達。終了します。")
+                        return
+                except Exception as e:
+                    print(f"[WARN] スプシ書き込み失敗: {home} -> {e}")
+                    traceback.print_exc()
+                    seen_roots.add(home)
 
     save_json(SEEN_PATH, {"roots": sorted(seen_roots)})
     print(f"[END] 追加 {added} 件で終了")


### PR DESCRIPTION
## Summary
- run a broad query once and page through results via `search_candidates_iter`
- when fewer than 30 candidates are added from the broad query, fall back to state-based queries

## Testing
- `pytest` *(fails: FileNotFoundError: service_account.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aac01ba2c48322ad9d19b411ad1bcd