### PR TITLE
Simplify service account setup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,14 +29,7 @@ jobs:
         run: pip install -r requirements_smart.txt
 
       - name: Write service account json
-        # SecretのSERVICE_ACCOUNT_JSONをファイル化
-        run: |
-          python - <<'PY'
-          import os, pathlib
-          p = pathlib.Path('service_account.json')
-          p.write_text(os.environ['SERVICE_ACCOUNT_JSON'])
-          print('wrote', p, 'bytes=', p.stat().st_size)
-          PY
+        run: echo "$SERVICE_ACCOUNT_JSON" > service_account.json
         env:
           SERVICE_ACCOUNT_JSON: ${{ secrets.SERVICE_ACCOUNT_JSON }}
 


### PR DESCRIPTION
## Summary
- write service account json via echo before running pipeline

## Testing
- `pytest` *(fails: FileNotFoundError: No such file or directory: 'service_account.json')*

------
https://chatgpt.com/codex/tasks/task_e_68ab178025bc8322a8a4ef918280d859