### PR TITLE
feat: increase query limit per run

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,7 @@ jobs:
       TARGET_NEW: ${{ github.event.inputs.target_new }}
       DEBUG: "1"                      # 詳細ログ（不要なら消してOK）
       SKIP_SHEETS: "0"
+      MAX_QUERIES_PER_RUN: "800"      # 1回の実行での検索上限
     steps:
       - uses: actions/checkout@v4
 

--- a/pipeline_smart.py
+++ b/pipeline_smart.py
@@ -103,7 +103,7 @@ def main():
 
     added = 0
     cse = CSEClient(api_key, cx, max_daily=int(os.getenv("MAX_DAILY_CSE_QUERIES","100")))
-    max_queries = int(os.getenv("MAX_QUERIES_PER_RUN", "50"))
+    max_queries = int(os.getenv("MAX_QUERIES_PER_RUN", "800"))
 
     # まず広域クエリをページ巡回しながら収集
     wide_q = os.getenv(


### PR DESCRIPTION
## Summary
- raise default MAX_QUERIES_PER_RUN to 800
- allow GitHub Actions runs to use the higher cap

## Testing
- `pytest` *(fails: FileNotFoundError: service_account.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1c378cdc8322b217f432110ef1f8