### PR TITLE
Add noise domain exclusions and lower per-run query cap

### DIFF
--- a/light_extract.py
+++ b/light_extract.py
@@ -14,7 +14,9 @@ BLOCK_DOMAINS = {
     "facebook.com","m.facebook.com","instagram.com","tiktok.com","reddit.com","vogue.com",
     "theinfatuation.com","eater.com","la.eater.com","ny.eater.com","toasttab.com","square.site",
     "linktr.ee","google.com","maps.google.com","order.online","order.alfred.la",
-    "vivinavi.com","vividnavigation.com"
+    "vivinavi.com","vividnavigation.com","uber.com","pos.chowbus.com","chowbus.com",
+    "fantuanorder.com","appfront.app","mapquest.com","linkedin.com","x.com","amazon.com",
+    "walmart.com"
 }
 
 MATCHA_WORDS = re.compile(r'(matcha|抹茶|green\s*tea\s*latte|ceremonial\s*matcha|iced\s*matcha|dirty\s*matcha)', re.I)


### PR DESCRIPTION
## Summary
- filter out common noise domains in CSE queries using a shared exclude list
- lower `MAX_QUERIES_PER_RUN` default to 200 to avoid quota exhaustion
- expand crawler blocklist with additional delivery and platform domains

## Testing
- `pytest -q` *(fails: FileNotFoundError: No such file or directory: 'service_account.json')*


------
https://chatgpt.com/codex/tasks/task_e_68ab1f5bcd188322b9df3c3ab3176579