### PR TITLE
feat: refine search filters and add skip breaker

### DIFF
--- a/cse_client.py
+++ b/cse_client.py
@@ -55,12 +55,16 @@ class CSEClient:
                 return True
         return False
 
-    def search(self, q, start=1, num=10, safe="off", lr=None, cr=None):
+    def search(self, q, start=1, num=10, safe="off", lr=None, cr=None, gl=None):
         if self.remaining() <= 0:
             raise DailyQuotaExceeded("Daily query budget exhausted")
         params = {"key": self.api_key, "cx": self.cx, "q": q, "num": num, "start": start, "safe": safe}
-        if lr: params["lr"] = lr
-        if cr: params["cr"] = cr
+        if lr:
+            params["lr"] = lr
+        if cr:
+            params["cr"] = cr
+        if gl:
+            params["gl"] = gl
         url = "https://www.googleapis.com/customsearch/v1"
         try:
             resp = requests.get(url, params=params, timeout=self.timeout)

--- a/search_google.py
+++ b/search_google.py
@@ -9,6 +9,8 @@ def _base_params(query, num=10):
         "q": query,
         "num": num,
         "lr": "lang_en",
+        "cr": "countryUS",
+        "gl": "us",
     }
 
 def search_candidates(query, num=10):


### PR DESCRIPTION
## Summary
- expand noise-domain exclusions and refine default queries
- add `gl` parameter to CSE requests
- introduce skip breaker and lower per-run query cap

## Testing
- `pytest -q` *(fails: FileNotFoundError: 'service_account.json')*
- `pytest test_pipeline_smart_entrypoint.py test_verify_matcha.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac5ed7044083228741ee0b3f75493b