### PR TITLE
feat: cap per-run queries to 120

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Matcha Finder
+
+Utilities for discovering matcha-serving cafes and collecting contact info.
+
+## Query limits
+
+`pipeline_smart.py` issues Google CSE queries to discover new sites. To prevent
+excessive usage, the script caps the number of queries per execution. The default
+is 120 queries, but it can be adjusted by setting the `MAX_QUERIES_PER_RUN`
+environment variable:
+
+```bash
+export MAX_QUERIES_PER_RUN=80
+python pipeline_smart.py
+```
+
+Lowering this value is useful to avoid hitting API limits or generating too many
+requests in a single run.

--- a/pipeline_smart.py
+++ b/pipeline_smart.py
@@ -129,7 +129,9 @@ def main():
 
     added = 0
     cse = CSEClient(api_key, cx, max_daily=int(os.getenv("MAX_DAILY_CSE_QUERIES","100")))
-    max_queries = int(os.getenv("MAX_QUERIES_PER_RUN", "150"))
+    # Limit how many CSE queries are issued per run. Can be overridden via
+    # the MAX_QUERIES_PER_RUN environment variable.
+    max_queries = int(os.getenv("MAX_QUERIES_PER_RUN", "120"))
     skip_breaker = int(os.getenv("SKIP_BREAKER", "60"))
     skip_streak = 0
 


### PR DESCRIPTION
## Summary
- limit default per-run CSE queries to 120 in pipeline_smart
- document `MAX_QUERIES_PER_RUN` override to avoid excessive API usage

## Testing
- `pytest -q` *(fails: FileNotFoundError: 'service_account.json')*


------
https://chatgpt.com/codex/tasks/task_e_68ac643d85ec8322bd2788e4a468b97f