### PR TITLE
Refine matcha search accuracy

### DIFF
--- a/requirements_smart.txt
+++ b/requirements_smart.txt
@@ -1,7 +1,10 @@
-﻿requests
+requests
 gspread
 google-auth
 python-dotenv
 beautifulsoup4
 lxml
 pdfminer.six
+PyPDF2
+Pillow
+pytesseract


### PR DESCRIPTION
## Summary
- Filter broad CSE results with snippet checks to avoid irrelevant domains
- Add `verify_matcha` menu and site verification with OCR and PDF fallback
- Introduce `iter_cse_items` for paginated CSE queries and apply stricter evidence checks in state queries
- Fix missing OCR/PDF dependencies in `requirements_smart.txt`

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*
- `pip install --break-system-packages -r requirements_smart.txt` *(fails: proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ac65a056808322ae19eb5dfa10c8bf