### PR TITLE
Add Pillow dependency

### DIFF
--- a/requirements_smart.txt
+++ b/requirements_smart.txt
@@ -5,3 +5,4 @@ python-dotenv
 beautifulsoup4
 lxml
 pdfminer.six
+Pillow


### PR DESCRIPTION
## Summary
- include Pillow in requirements_smart to provide PIL module

## Testing
- ⚠️ `pip install -r requirements_smart.txt` (proxy blocked pdfminer.six)
- ⚠️ `pytest` (test suite exits early via SystemExit in test_sheet)
- ✅ `pytest test_verify_matcha.py`


------
https://chatgpt.com/codex/tasks/task_e_68adb46b5c3483229f9ab55374ecb237