### PR TITLE
ci: add PyPDF2 and dependency smoke test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,29 @@ jobs:
       - name: Install deps
         run: pip install -r requirements_smart.txt
 
+      - name: Show requirements_smart.txt
+        run: |
+          echo "===== requirements_smart.txt ====="
+          cat requirements_smart.txt || true
+
+      - name: Dependency smoke test
+        run: |
+          python -m pip check
+          python - <<'PY'
+          import importlib, sys
+          mods = ["PIL","PyPDF2","gspread","bs4","lxml","pdfminer","google.oauth2"]
+          missing = []
+          for m in mods:
+              try:
+                  importlib.import_module(m)
+              except Exception as e:
+                  missing.append(f"{m}: {e}")
+          if missing:
+              print("Missing modules:\n" + "\n".join(missing))
+              sys.exit(1)
+          print("All imports OK")
+          PY
+
       - name: Write service account json
         run: echo "$SERVICE_ACCOUNT_JSON" > service_account.json
         env:

--- a/requirements_smart.txt
+++ b/requirements_smart.txt
@@ -6,3 +6,4 @@ beautifulsoup4
 lxml
 pdfminer.six
 Pillow
+PyPDF2>=3,<4


### PR DESCRIPTION
## Summary
- ensure PyPDF2 is installed by listing it in requirements_smart.txt
- print the requirements file and run a dependency smoke test in CI

## Testing
- `pip install -r requirements_smart.txt` *(fails: Could not find a version that satisfies the requirement pdfminer.six)*
- `pytest -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'service_account.json')*

## Cause
CI failed because PyPDF2 was not installed. Relevant log excerpt: `ModuleNotFoundError: No module named 'PyPDF2'`

------
https://chatgpt.com/codex/tasks/task_e_68adc0ff4f0c83229a7b9396cf4c2905