### PR TITLE
CI: enable Tesseract OCR (pytesseract + apt) and guard imports

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,11 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Install Tesseract OCR
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y tesseract-ocr tesseract-ocr-eng tesseract-ocr-jpn tesseract-ocr-jpn-vert
+
       - name: Install deps
         run: pip install -r requirements_smart.txt
 
@@ -50,6 +55,30 @@ jobs:
               print("Missing modules:\n" + "\n".join(missing))
               sys.exit(1)
           print("All imports OK")
+          PY
+
+      - name: Dependency smoke test (OCR)
+        run: |
+          tesseract --version
+          python - <<'PY'
+          import importlib, shutil, sys, pytesseract
+          mods = ["PIL","PyPDF2","pytesseract","gspread","bs4","lxml","pdfminer","google.oauth2"]
+          missing = []
+          for m in mods:
+              try:
+                  importlib.import_module(m)
+              except Exception as e:
+                  missing.append(f"{m}: {e}")
+          if not shutil.which("tesseract"):
+              missing.append("tesseract binary: not found in PATH")
+          try:
+              pytesseract.get_tesseract_version()
+          except Exception as e:
+              missing.append(f"pytesseract linkage: {e}")
+          if missing:
+              print("Missing/Issues:\n" + "\n".join(missing))
+              sys.exit(1)
+          print("All good: pytesseract and tesseract are ready")
           PY
 
       - name: Write service account json

--- a/requirements_smart.txt
+++ b/requirements_smart.txt
@@ -7,3 +7,4 @@ lxml
 pdfminer.six
 Pillow
 PyPDF2>=3,<4
+pytesseract>=0.3.13,<0.4

--- a/verify_matcha.py
+++ b/verify_matcha.py
@@ -2,7 +2,10 @@
 from bs4 import BeautifulSoup
 from PIL import Image
 from PyPDF2 import PdfReader
-import pytesseract
+try:
+    import pytesseract  # type: ignore
+except ModuleNotFoundError:
+    pytesseract = None  # type: ignore
 
 # 語彙（過検知を避けるフィルタつき）
 KW_POSITIVE = [r"\bmatcha\b", r"\bmatcha\s+latte\b", r"抹茶"]
@@ -41,6 +44,11 @@ def _pdf_text(url: str)->str:
     except: return ""
 
 def _ocr_image_from_url(url: str)->str:
+    import shutil
+    if pytesseract is None:
+        raise RuntimeError("pytesseract が見つかりません。requirements と CI の Tesseract インストールを確認してください。")
+    if not shutil.which("tesseract"):
+        raise RuntimeError("tesseract バイナリが見つかりません。CIで 'apt-get install tesseract-ocr' を実行してください。")
     try:
         r = requests.get(url, timeout=15, stream=True)
         r.raise_for_status()


### PR DESCRIPTION
## Summary
- install `pytesseract` dependency
- install Tesseract OCR packages before Python deps and add smoke tests
- guard `pytesseract` import and ensure OCR has required binaries

## Testing
- `python -m pip check`
- `pytest -q test_verify_matcha.py`

## Failure context
```
ModuleNotFoundError: No module named 'pytesseract'
```

------
https://chatgpt.com/codex/tasks/task_e_68adc596dc1483228a3492915e2fdae8