### PR TITLE
Expand US cafe detection with state/menu heuristic

### DIFF
--- a/test_is_us_cafe_site.py
+++ b/test_is_us_cafe_site.py
@@ -1,0 +1,16 @@
+import sys, types
+
+pdfminer_stub = types.ModuleType("pdfminer")
+high_level_stub = types.ModuleType("pdfminer.high_level")
+high_level_stub.extract_text = lambda *a, **k: ""
+pdfminer_stub.high_level = high_level_stub
+sys.modules.setdefault("pdfminer", pdfminer_stub)
+sys.modules.setdefault("pdfminer.high_level", high_level_stub)
+
+import light_extract
+
+
+def test_state_with_menu(monkeypatch):
+    monkeypatch.setattr(light_extract, "http_get", lambda *a, **k: None)
+    html = "<html><body>local cafe menu CA</body></html>"
+    assert light_extract.is_us_cafe_site("https://example.com", html)


### PR DESCRIPTION
## Summary
- Broaden US cafe detection to match if ZIP/phone or state abbreviation with menu/contact present
- Emit debug logs describing which check failed inside `is_us_cafe_site`
- Add unit test for state abbreviation + menu heuristic

## Testing
- `pytest -q` *(fails: FileNotFoundError: 'service_account.json')*
- `pytest test_is_us_cafe_site.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68af0eb2c7b48322a0dc7e4090205a9e