### PR TITLE
Centralize domain filter lists and add mall domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,10 @@ python pipeline_smart.py
 
 Lowering this value is useful to avoid hitting API limits or generating too many
 requests in a single run.
+
+## Domain filters
+
+Noise domains encountered during searches or crawling are centralized in
+`matcha_finder/domain_filters.py`. Update `EXCLUDE_SITES` and `BLOCK_DOMAINS`
+when logs show repeated false positives. Keep the lists alphabetized and commit
+the change so both the query builder and extractor stay in sync.

--- a/light_extract.py
+++ b/light_extract.py
@@ -3,21 +3,11 @@ import requests
 from bs4 import BeautifulSoup
 from urllib.parse import urljoin, urlsplit, urlunsplit
 from pdfminer.high_level import extract_text as pdf_extract_text
+from matcha_finder.domain_filters import BLOCK_DOMAINS
 
 HDRS = {"User-Agent": "Mozilla/5.0 (compatible; MatchaFinder/1.0)"}
 TIMEOUT = float(os.getenv("HTTP_TIMEOUT", "10"))
 
-BLOCK_DOMAINS = {
-    # メディア/まとめ/配達/予約/大手SNS
-    "yelp.com","m.yelp.com","ubereats.com","doordash.com","grubhub.com","seamless.com",
-    "opentable.com","resy.com","sevenrooms.com","tripadvisor.com","pinterest.com",
-    "facebook.com","m.facebook.com","instagram.com","tiktok.com","reddit.com","vogue.com",
-    "theinfatuation.com","eater.com","la.eater.com","ny.eater.com","toasttab.com","square.site",
-    "linktr.ee","google.com","maps.google.com","order.online","order.alfred.la",
-    "vivinavi.com","vividnavigation.com","uber.com","pos.chowbus.com","chowbus.com",
-    "fantuanorder.com","appfront.app","mapquest.com","linkedin.com","x.com","amazon.com",
-    "walmart.com"
-}
 
 MATCHA_WORDS = re.compile(r'(matcha|抹茶|green\s*tea\s*latte|ceremonial\s*matcha|iced\s*matcha|dirty\s*matcha)', re.I)
 CAFE_HINTS   = re.compile(r'\b(cafe|coffee|tea|teahouse|bakery|boba|bubble\s*tea)\b', re.I)

--- a/matcha_finder/__init__.py
+++ b/matcha_finder/__init__.py
@@ -1,0 +1,1 @@
+"""Matcha Finder shared utilities."""

--- a/matcha_finder/domain_filters.py
+++ b/matcha_finder/domain_filters.py
@@ -1,0 +1,48 @@
+"""Domain filtering constants used across Matcha Finder.
+
+`EXCLUDE_SITES` is used when building Google Custom Search queries to remove
+common noise domains. `BLOCK_DOMAINS` is consulted when crawling pages to avoid
+following or normalizing links from known non-target hosts.
+
+When logs reveal new noisy domains, append them to the appropriate list below
+and keep the lists alphabetized for easier maintenance.
+"""
+
+# Google CSEで除外したいノイズドメイン
+EXCLUDE_SITES = [
+    # SNS / UGC / メディア
+    "instagram.com", "tiktok.com", "reddit.com", "pinterest.com",
+    "linkedin.com", "x.com", "quora.com", "flickr.com", "goodreads.com",
+    "timeout.com", "eater.com", "theinfatuation.com", "sfchronicle.com",
+    "sacbee.com", "king5.com", "thenewstribune.com", "wanderlog.com",
+    "trip.com", "lemon8-app.com",
+    # デリバリー / モール / 求人 / 注文ホスティング等
+    "yelp.com", "ubereats.com", "doordash.com", "postmates.com",
+    "seamless.com", "grubhub.com", "mercato.com", "order.online",
+    "toasttab.com", "toast.site", "orderexperience.net", "appfront.app",
+    "res-menu.com", "craverapp.com", "square.site", "mapquest.com",
+    "indeed.com", "glassdoor.com", "rockefellercenter.com",
+    "tysonscornercenter.com", "westfield.com",
+    # 量販 / EC / ティーブランド等
+    "amazon.com", "walmart.com", "samsclub.com", "sayweee.com",
+    "centralmarket.com", "uwajimaya.com", "jadeleafmatcha.com",
+    "isshikimatcha.com", "cuzenmatcha.com", "senbirdtea.com",
+    # チェーン店
+    "starbucks.com", "starbucksreserve.com", "bluebottlecoffee.com",
+    "peets.com", "dutchbros.com", "arabicacoffeeus.com",
+    "85cbakerycafe.com", "parisbaguette.com", "lalalandkindcafe.com",
+    "nanasgreentea.com", "nanasgreenteaus.com", "chachamatcha.com",
+    "kettl.co", "matchaful.com",
+]
+
+# クロール時に無視するドメイン
+BLOCK_DOMAINS = {
+    "yelp.com", "m.yelp.com", "ubereats.com", "doordash.com", "grubhub.com", "seamless.com",
+    "opentable.com", "resy.com", "sevenrooms.com", "tripadvisor.com", "pinterest.com",
+    "facebook.com", "m.facebook.com", "instagram.com", "tiktok.com", "reddit.com", "vogue.com",
+    "theinfatuation.com", "eater.com", "la.eater.com", "ny.eater.com", "toasttab.com", "square.site",
+    "linktr.ee", "google.com", "maps.google.com", "order.online", "order.alfred.la",
+    "vivinavi.com", "vividnavigation.com", "uber.com", "pos.chowbus.com", "chowbus.com",
+    "fantuanorder.com", "appfront.app", "mapquest.com", "linkedin.com", "x.com", "amazon.com",
+    "walmart.com", "lemon8-app.com", "rockefellercenter.com", "tysonscornercenter.com", "westfield.com",
+}

--- a/pipeline_smart.py
+++ b/pipeline_smart.py
@@ -9,37 +9,12 @@ from light_extract import (
     extract_contacts, is_us_cafe_site, guess_brand, MATCHA_WORDS
 )
 from verify_matcha import verify_matcha
+from matcha_finder.domain_filters import EXCLUDE_SITES
 
 load_dotenv()
 
 SEEN_PATH = ".seen_roots.json"  # 既に検証したルートを保存（同じ結果の再検証を避ける）
 
-# Google CSE で除外したいノイズドメイン
-# Google CSE で除外したいノイズドメイン
-EXCLUDE_SITES = [
-    # SNS / UGC / メディア
-    "instagram.com", "tiktok.com", "reddit.com", "pinterest.com",
-    "linkedin.com", "x.com", "quora.com", "flickr.com", "goodreads.com",
-    "timeout.com", "eater.com", "theinfatuation.com", "sfchronicle.com",
-    "sacbee.com", "king5.com", "thenewstribune.com", "wanderlog.com",
-    "trip.com",
-    # デリバリー / モール / 求人 / 注文ホスティング等
-    "yelp.com", "ubereats.com", "doordash.com", "postmates.com",
-    "seamless.com", "grubhub.com", "mercato.com", "order.online",
-    "toasttab.com", "toast.site", "orderexperience.net", "appfront.app",
-    "res-menu.com", "craverapp.com", "square.site", "mapquest.com",
-    "indeed.com", "glassdoor.com",
-    # 量販 / EC / ティーブランド等
-    "amazon.com", "walmart.com", "samsclub.com", "sayweee.com",
-    "centralmarket.com", "uwajimaya.com", "jadeleafmatcha.com",
-    "isshikimatcha.com", "cuzenmatcha.com", "senbirdtea.com",
-    # チェーン店
-    "starbucks.com", "starbucksreserve.com", "bluebottlecoffee.com",
-    "peets.com", "dutchbros.com", "arabicacoffeeus.com",
-    "85cbakerycafe.com", "parisbaguette.com", "lalalandkindcafe.com",
-    "nanasgreentea.com", "nanasgreenteaus.com", "chachamatcha.com",
-    "kettl.co", "matchaful.com",
-]
 NEG_SITE_QUERY = " " + " ".join(f"-site:{d}" for d in EXCLUDE_SITES)
 
 # スニペット判定用（ベーカリー単独は除外）


### PR DESCRIPTION
## Summary
- factor out EXCLUDE_SITES and BLOCK_DOMAINS into matcha_finder/domain_filters.py
- import shared domain lists in pipeline_smart.py and light_extract.py
- document domain filter updates and add mall and social domains

## Testing
- ⚠️ `pytest` *(missing service_account.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adcb120e8483229302ba7cd6990615