### PR TITLE
feat: load region config and fallback search queries

### DIFF
--- a/config/regions.json
+++ b/config/regions.json
@@ -1,0 +1,11 @@
+{
+  "CA": ["Los Angeles", "San Francisco", "San Diego", "San Jose", "Sacramento"],
+  "NY": ["New York", "Brooklyn", "Queens", "Buffalo", "Rochester"],
+  "TX": ["Houston", "Dallas", "Austin", "San Antonio", "Fort Worth"],
+  "FL": ["Miami", "Orlando", "Tampa", "Jacksonville", "St Petersburg"],
+  "WA": ["Seattle", "Tacoma", "Bellevue"],
+  "MA": ["Boston", "Cambridge", "Worcester"],
+  "IL": ["Chicago", "Naperville", "Evanston"],
+  "CO": ["Denver", "Boulder", "Colorado Springs"],
+  "OR": ["Portland", "Eugene", "Salem"]
+}

--- a/pipeline_smart.py
+++ b/pipeline_smart.py
@@ -1,5 +1,6 @@
-﻿import os, json, traceback, re
+﻿import os, json, traceback, re, random
 import requests
+from pathlib import Path
 from dotenv import load_dotenv
 from cse_client import CSEClient, DailyQuotaExceeded
 from sheet_io_v2 import append_row_in_order, load_existing_keys
@@ -124,31 +125,42 @@ def iter_cse_items(cse: CSEClient, query: str, num=10, start=1, max_pages=1):
             yield it
         s += num
 
+def _region_queries(base_queries):
+    cfg_path = Path(__file__).resolve().parent / "config" / "regions.json"
+    try:
+        with open(cfg_path, encoding="utf-8") as f:
+            regions = json.load(f)
+    except Exception:
+        regions = {}
+
+    states_env = [s.strip() for s in os.getenv("STATES", "").split(",") if s.strip()]
+    states = states_env or list(regions.keys())
+    random.shuffle(states)
+    state_sample = int(os.getenv("STATE_SAMPLE", "5"))
+    states = states[:state_sample]
+    city_sample = int(os.getenv("CITY_SAMPLE", "5"))
+
+    out = []
+    for st in states:
+        out += [tmpl.format(kw=st) for tmpl in base_queries]
+        cities = regions.get(st, [])
+        random.shuffle(cities)
+        for city in cities[:city_sample]:
+            out += [tmpl.format(kw=f"{city} {st}") for tmpl in base_queries]
+    random.shuffle(out)
+    return out
+
 def default_queries():
-    # US に寄せるクエリ（繰り返しでもバリエーションが出るようランダム化）
     base = [
         f"(\"matcha latte\" OR \"matcha menu\" OR \"抹茶 ラテ\" OR \"抹茶 メニュー\") (cafe OR \"coffee house\" OR \"tea house\" OR bakery) {{kw}}{NEG_SITE_QUERY}"
     ]
-    states = [s.strip() for s in os.getenv("STATES","CA,NY,TX,FL,WA,MA,IL,CO,OR").split(",") if s.strip()]
-    cities = {
-        "CA": ["Los Angeles","San Francisco","San Diego","San Jose","Sacramento"],
-        "NY": ["New York","Brooklyn","Queens","Buffalo","Rochester"],
-        "TX": ["Houston","Dallas","Austin","San Antonio","Fort Worth"],
-        "FL": ["Miami","Orlando","Tampa","Jacksonville","St Petersburg"],
-        "WA": ["Seattle","Tacoma","Bellevue"],
-        "MA": ["Boston","Cambridge","Worcester"],
-        "IL": ["Chicago","Naperville","Evanston"],
-        "CO": ["Denver","Boulder","Colorado Springs"],
-        "OR": ["Portland","Eugene","Salem"],
-    }
-    out=[]
-    for st in states:
-        out += [tmpl.format(kw=st) for tmpl in base]
-        for city in cities.get(st, [])[:5]:
-            out += [tmpl.format(kw=f"{city} {st}") for tmpl in base]
-    import random
-    random.shuffle(out)
-    return out
+    return _region_queries(base)
+
+def fallback_queries():
+    base = [
+        f"(matcha OR 抹茶) (dessert cafe OR bubble tea shop) {{kw}}{NEG_SITE_QUERY}"
+    ]
+    return _region_queries(base)
 
 def main():
     api_key = os.getenv("GOOGLE_API_KEY")
@@ -177,19 +189,167 @@ def main():
     max_queries = int(os.getenv("MAX_QUERIES_PER_RUN", "120"))
     skip_breaker = int(os.getenv("SKIP_BREAKER", "60"))
     skip_streak = 0
+    fallback_mode = False
+    queries_run = 0
 
     def on_skip():
-        nonlocal skip_streak
+        nonlocal skip_streak, fallback_mode
         skip_streak += 1
         if skip_streak >= skip_breaker:
-            save_json(SEEN_PATH, {"roots": sorted(seen_roots)})
-            print("[STOP] too many consecutive skips")
-            return True
+            if not fallback_mode:
+                fallback_mode = True
+                skip_streak = 0
+                print("[INFO] switching to fallback queries")
+            else:
+                save_json(SEEN_PATH, {"roots": sorted(seen_roots)})
+                print("[STOP] too many consecutive skips")
+                return True
         return False
 
     def on_add():
         nonlocal skip_streak
         skip_streak = 0
+
+    def run_query_batch(q_list):
+        nonlocal added, fallback_mode, queries_run
+        for q in q_list:
+            if queries_run >= max_queries:
+                if debug:
+                    print("[STOP] per-run query cap reached")
+                return True
+            queries_run += 1
+            try:
+                data = cse.search(q, start=1, num=10, safe="off", lr="lang_en", cr="countryUS", gl="us")
+            except DailyQuotaExceeded:
+                print("[STOP] Google CSE 日次上限/レート制限に到達。")
+                return True
+            except Exception as e:
+                if debug: print(f"search error: {e}")
+                continue
+
+            for it in (data.get("items") or []):
+                raw = (it.get("link") or "").strip()
+                home = normalize_candidate_url(raw)
+                if not home:
+                    if debug: print(f"skip[{raw}]: blocked or empty")
+                    if on_skip():
+                        return True
+                    if fallback_mode:
+                        return False
+                    continue
+                if home in seen_roots:
+                    if debug: print(f"skip[{home}]: already-seen root")
+                    if on_skip():
+                        return True
+                    if fallback_mode:
+                        return False
+                    continue
+                if home in seen_homes:
+                    if debug: print(f"skip[{home}]: already-in-sheet")
+                    if on_skip():
+                        return True
+                    if fallback_mode:
+                        return False
+                    continue
+
+                if not snippet_ok(it, home):
+                    if debug: print(f"skip[{home}]: snippet not matcha or platform")
+                    seen_roots.add(home)
+                    if on_skip():
+                        return True
+                    if fallback_mode:
+                        return False
+                    continue
+
+                r = http_get(home)
+                html = r.text if (r and r.text) else ""
+                if not html:
+                    if debug: print(f"skip[{home}]: no html")
+                    seen_roots.add(home)
+                    if on_skip():
+                        return True
+                    if fallback_mode:
+                        return False
+                    continue
+
+                ig, emails, form = extract_contacts(home, html)
+                menus = list(find_menu_links(html, home, limit=3))
+                how, evidence = verify_matcha(menus, ig, html_text(html))
+                ok = bool(how)
+                if not ok:
+                    ok = mini_site_matcha(cse, home)
+
+                if not ok:
+                    if debug: print(f"skip[{home}]: no matcha evidence")
+                    seen_roots.add(home)
+                    if on_skip():
+                        return True
+                    if fallback_mode:
+                        return False
+                    continue
+
+                if not is_us_cafe_site(home, html):
+                    if debug: print(f"skip[{home}]: not US independent cafe")
+                    seen_roots.add(home)
+                    if on_skip():
+                        return True
+                    if fallback_mode:
+                        return False
+                    continue
+
+                if require_contact_on_snippet and not (ig or emails or form):
+                    if debug: print(f"skip[{home}]: no contacts found")
+                    seen_roots.add(home)
+                    if on_skip():
+                        return True
+                    if fallback_mode:
+                        return False
+                    continue
+
+                ig_key = canon_url(ig) if ig else ""
+                if ig_key and ig_key in seen_instas:
+                    if debug: print(f"skip[{home}]: dup insta")
+                    seen_roots.add(home)
+                    if on_skip():
+                        return True
+                    if fallback_mode:
+                        return False
+                    continue
+
+                brand = guess_brand(home, html, it.get("title") or "")
+                row = {
+                    "店名": brand,
+                    "国": "US",
+                    "公式サイトURL": home,
+                    "Instagramリンク": ig,
+                    "問い合わせアドレス": (emails[0] if emails else ""),
+                    "問い合わせフォームURL": form,
+                }
+
+                try:
+                    append_row_in_order(sheet_id, ws_name, row)
+                    added += 1
+                    on_add()
+                    seen_homes.add(home)
+                    if ig_key:
+                        seen_instas.add(ig_key)
+                    seen_roots.add(home)
+                    print(
+                        f"[ADD] {brand} -> {home} contacts: ig={ig or '-'} email={(emails[0] if emails else '-')} form={form or '-'} （累計 {added}）"
+                    )
+                    if added >= target:
+                        save_json(SEEN_PATH, {"roots": sorted(seen_roots)})
+                        print("[DONE] 目標件数に到達。終了します。")
+                        return True
+                except Exception as e:
+                    print(f"[WARN] スプシ書き込み失敗: {home} -> {e}")
+                    traceback.print_exc()
+                    seen_roots.add(home)
+                    if on_skip():
+                        return True
+                    if fallback_mode:
+                        return False
+        return False
 
     # まず広域クエリをページ巡回しながら収集
     wide_q = os.getenv(
@@ -204,22 +364,30 @@ def main():
                 if debug: print(f"skip[{raw}]: blocked or empty")
                 if on_skip():
                     return
+                if fallback_mode:
+                    break
                 continue
             if home in seen_roots:
                 if debug: print(f"skip[{home}]: already-seen root")
                 if on_skip():
                     return
+                if fallback_mode:
+                    break
                 continue
             if home in seen_homes:
                 if debug: print(f"skip[{home}]: already-in-sheet")
                 if on_skip():
                     return
+                if fallback_mode:
+                    break
                 continue
             if not snippet_ok(it, home):
                 if debug: print(f"skip[{home}]: snippet not matcha or platform")
                 seen_roots.add(home)
                 if on_skip():
                     return
+                if fallback_mode:
+                    break
                 continue
 
             # ランディング取得
@@ -230,6 +398,8 @@ def main():
                 seen_roots.add(home)
                 if on_skip():
                     return
+                if fallback_mode:
+                    break
                 continue
 
             ig, emails, form = extract_contacts(home, html)
@@ -244,6 +414,8 @@ def main():
                 seen_roots.add(home)
                 if on_skip():
                     return
+                if fallback_mode:
+                    break
                 continue
 
             if not is_us_cafe_site(home, html):
@@ -251,6 +423,8 @@ def main():
                 seen_roots.add(home)
                 if on_skip():
                     return
+                if fallback_mode:
+                    break
                 continue
 
             if require_contact_on_snippet and not (ig or emails or form):
@@ -258,6 +432,8 @@ def main():
                 seen_roots.add(home)
                 if on_skip():
                     return
+                if fallback_mode:
+                    break
                 continue
 
             ig_key = canon_url(ig) if ig else ""
@@ -266,6 +442,8 @@ def main():
                 seen_roots.add(home)
                 if on_skip():
                     return
+                if fallback_mode:
+                    break
                 continue
 
             brand = guess_brand(home, html, it.get("title") or "")
@@ -299,131 +477,21 @@ def main():
                 seen_roots.add(home)
                 if on_skip():
                     return
+                if fallback_mode:
+                    break
     except Exception as e:
         if debug:
             print(f"search_iter error: {e}")
 
-    # 広域クエリで30件未満なら州別クエリで補完
-    if added < 30:
-        queries = default_queries()
-        for idx, q in enumerate(queries):
-            if idx >= max_queries:
-                if debug:
-                    print("[STOP] per-run query cap reached")
-                break
-            try:
-                data = cse.search(q, start=1, num=10, safe="off", lr="lang_en", cr="countryUS", gl="us")
-            except DailyQuotaExceeded:
-                print("[STOP] Google CSE 日次上限/レート制限に到達。")
-                break
-            except Exception as e:
-                if debug: print(f"search error: {e}")
-                continue
-
-            for it in (data.get("items") or []):
-                raw = (it.get("link") or "").strip()
-                home = normalize_candidate_url(raw)
-                if not home:
-                    if debug: print(f"skip[{raw}]: blocked or empty")
-                    if on_skip():
-                        return
-                    continue
-                if home in seen_roots:
-                    if debug: print(f"skip[{home}]: already-seen root")
-                    if on_skip():
-                        return
-                    continue
-                if home in seen_homes:
-                    if debug: print(f"skip[{home}]: already-in-sheet")
-                    if on_skip():
-                        return
-                    continue
-
-                # 1) スニペット事前判定（US向け/プラットフォーム除外）
-                if not snippet_ok(it, home):
-                    if debug: print(f"skip[{home}]: snippet not matcha or platform")
-                    seen_roots.add(home)
-                    if on_skip():
-                        return
-                    continue
-
-                # 2) ランディング取得
-                r = http_get(home)
-                html = r.text if (r and r.text) else ""
-                if not html:
-                    if debug: print(f"skip[{home}]: no html")
-                    seen_roots.add(home)
-                    if on_skip():
-                        return
-                    continue
-
-                ig, emails, form = extract_contacts(home, html)
-                menus = list(find_menu_links(html, home, limit=3))
-                how, evidence = verify_matcha(menus, ig, html_text(html))
-                ok = bool(how)
-                if not ok:
-                    ok = mini_site_matcha(cse, home)
-
-                if not ok:
-                    if debug: print(f"skip[{home}]: no matcha evidence")
-                    seen_roots.add(home)
-                    if on_skip():
-                        return
-                    continue
-
-                if not is_us_cafe_site(home, html):
-                    if debug: print(f"skip[{home}]: not US independent cafe")
-                    seen_roots.add(home)
-                    if on_skip():
-                        return
-                    continue
-
-                if require_contact_on_snippet and not (ig or emails or form):
-                    if debug: print(f"skip[{home}]: no contacts found")
-                    seen_roots.add(home)
-                    if on_skip():
-                        return
-                    continue
-
-                ig_key = canon_url(ig) if ig else ""
-                if ig_key and ig_key in seen_instas:
-                    if debug: print(f"skip[{home}]: dup insta")
-                    seen_roots.add(home)
-                    if on_skip():
-                        return
-                    continue
-
-                brand = guess_brand(home, html, it.get("title") or "")
-                row = {
-                    "店名": brand,
-                    "国": "US",
-                    "公式サイトURL": home,
-                    "Instagramリンク": ig,
-                    "問い合わせアドレス": (emails[0] if emails else ""),
-                    "問い合わせフォームURL": form,
-                }
-
-                try:
-                    append_row_in_order(sheet_id, ws_name, row)
-                    added += 1
-                    on_add()
-                    seen_homes.add(home)
-                    if ig_key:
-                        seen_instas.add(ig_key)
-                    seen_roots.add(home)
-                    print(
-                        f"[ADD] {brand} -> {home} contacts: ig={ig or '-'} email={(emails[0] if emails else '-')} form={form or '-'} （累計 {added}）"
-                    )
-                    if added >= target:
-                        save_json(SEEN_PATH, {"roots": sorted(seen_roots)})
-                        print("[DONE] 目標件数に到達。終了します。")
-                        return
-                except Exception as e:
-                    print(f"[WARN] スプシ書き込み失敗: {home} -> {e}")
-                    traceback.print_exc()
-                    seen_roots.add(home)
-                    if on_skip():
-                        return
+    # 広域クエリで30件未満、またはスキップが多い場合は州別クエリで補完
+    if added < 30 or fallback_mode:
+        initial_fallback = fallback_mode
+        queries = fallback_queries() if fallback_mode else default_queries()
+        if run_query_batch(queries):
+            return
+        if fallback_mode and not initial_fallback:
+            if run_query_batch(fallback_queries()):
+                return
 
     save_json(SEEN_PATH, {"roots": sorted(seen_roots)})
     print(f"[END] 追加 {added} 件で終了")


### PR DESCRIPTION
## Summary
- move state/city data into `config/regions.json`
- load regions config and randomize selection in `default_queries`
- switch to fallback queries when skip streak is too high

## Testing
- `pytest` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'service_account.json')*


------
https://chatgpt.com/codex/tasks/task_e_68adcb164b5c832289f95419da4b1126