### PR TITLE
Enhance US cafe detection via address parsing and geocoding

### DIFF
--- a/test_verify_matcha.py
+++ b/test_verify_matcha.py
@@ -1,4 +1,14 @@
 from verify_matcha import _has_matcha_text
+import types, sys
+
+pdfminer = types.ModuleType("pdfminer")
+high_level = types.ModuleType("high_level")
+high_level.extract_text = lambda *a, **k: ""
+pdfminer.high_level = high_level
+sys.modules["pdfminer"] = pdfminer
+sys.modules["pdfminer.high_level"] = high_level
+
+import light_extract
 
 
 def test_direct_matcha_word():
@@ -12,3 +22,21 @@ def test_secondary_keyword_without_matcha():
 
 def test_negative_word_only():
     assert not _has_matcha_text("Houjicha and sencha available")
+
+
+def test_is_us_cafe_from_address(monkeypatch):
+    html = """<html><body><p>Cozy cafe</p><address>123 Road, Seattle, WA</address></body></html>"""
+    monkeypatch.setattr(light_extract, "geocode_city_state", lambda c, s: True)
+    assert light_extract.is_us_cafe_site("https://example.com", html)
+
+
+def test_is_us_cafe_from_postaladdress(monkeypatch):
+    html = (
+        """
+<html><head><script type="application/ld+json">
+{"@context":"https://schema.org","@type":"Cafe","address":{"@type":"PostalAddress","addressLocality":"Austin","addressRegion":"TX"}}
+</script></head><body>Tea House</body></html>
+"""
+    )
+    monkeypatch.setattr(light_extract, "geocode_city_state", lambda c, s: True)
+    assert light_extract.is_us_cafe_site("https://example.com", html)


### PR DESCRIPTION
## Summary
- Parse `<address>` and schema.org `PostalAddress` blocks for city/state info
- Add cached geocoding lookup for city/state-only matches
- Test new detection paths for HTML `<address>` and JSON-LD `PostalAddress`

## Testing
- `pytest test_verify_matcha.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68adcb164d9c83228866f6735601948e