### PR TITLE
Guard external tests with environment checks

### DIFF
--- a/test_cse.py
+++ b/test_cse.py
@@ -1,8 +1,31 @@
-﻿from dotenv import load_dotenv; load_dotenv()
-import os, requests
-key=os.getenv("GOOGLE_API_KEY"); cx=os.getenv("GOOGLE_CSE_ID")
-print("GOOGLE_API_KEY set?:", bool(key))
-print("GOOGLE_CSE_ID     :", cx)
-r=requests.get("https://www.googleapis.com/customsearch/v1",
-               params={"key":key,"cx":cx,"q":"matcha cafe CA","num":1}, timeout=15)
-print("HTTP", r.status_code, r.json().get("searchInformation",{}))
+import os
+
+import pytest
+import requests
+from dotenv import load_dotenv
+
+
+load_dotenv()
+
+
+def test_google_cse():
+    """Simple query against the Google Custom Search API.
+
+    The test is skipped when the required API credentials are not
+    supplied via environment variables.
+    """
+
+    key = os.getenv("GOOGLE_API_KEY")
+    cx = os.getenv("GOOGLE_CSE_ID")
+    if not key or not cx:
+        pytest.skip("Google CSE credentials not configured")
+
+    resp = requests.get(
+        "https://www.googleapis.com/customsearch/v1",
+        params={"key": key, "cx": cx, "q": "matcha cafe CA", "num": 1},
+        timeout=15,
+    )
+
+    assert resp.status_code == 200
+    assert "searchInformation" in resp.json()
+

--- a/test_sheet.py
+++ b/test_sheet.py
@@ -1,29 +1,35 @@
-﻿import os, time, sys
-from dotenv import load_dotenv
+import os
+import time
+
 import gspread
+import pytest
+from dotenv import load_dotenv
 
-load_dotenv()  # .env を読む
-sheet_id  = os.environ.get("SHEET_ID")
-ws_name   = os.environ.get("GOOGLE_WORKSHEET_NAME", "raw")
-sa_json   = os.environ.get("GOOGLE_SERVICE_ACCOUNT_JSON", "service_account.json")
 
-print(f"[check] SHEET_ID={sheet_id}")
-print(f"[check] WORKSHEET={ws_name}")
-print(f"[check] SA_JSON={sa_json}")
+load_dotenv()
 
-try:
+
+def test_append_row_to_sheet():
+    """Append a simple healthcheck row to the Google Sheet.
+
+    The test requires Google Sheets credentials. If they are not
+    configured, the test is skipped so that the rest of the suite can
+    run in environments without external access.
+    """
+
+    sheet_id = os.environ.get("SHEET_ID")
+    ws_name = os.environ.get("GOOGLE_WORKSHEET_NAME", "raw")
+    sa_json = os.environ.get("GOOGLE_SERVICE_ACCOUNT_JSON", "service_account.json")
+
+    if not sheet_id or not os.path.exists(sa_json):
+        pytest.skip("Google Sheets credentials not configured")
+
     gc = gspread.service_account(filename=sa_json)
     sh = gc.open_by_key(sheet_id)
     ws = sh.worksheet(ws_name)
     row = ["_healthcheck_", time.strftime("%Y-%m-%d %H:%M:%S")]
     ws.append_row(row)
-    print("[OK] appended one _healthcheck_ row.")
-except gspread.exceptions.WorksheetNotFound:
-    print(f"[NG] ワークシート '{ws_name}' が見つかりません。タブ名を合わせてください。")
-    sys.exit(2)
-except gspread.exceptions.SpreadsheetNotFound:
-    print("[NG] シートIDが不正、またはシェア権限がありません（サービスアカウントに編集者権限を付与してください）。")
-    sys.exit(3)
-except Exception as e:
-    print("[NG] 予期せぬエラー:", repr(e))
-    sys.exit(1)
+
+    # If the above operations succeed without exception, the test passes.
+    assert True
+


### PR DESCRIPTION
## Summary
- prevent Google Sheet health check from running when credentials are missing
- skip Google Custom Search API exercise unless API key and engine ID are provided

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af11861e648322b09198de4225231a