### PR TITLE
Ensure crawler reaches target with robust stopping logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ intent terms and excludes common noise domains.  Configuration lives in
 | `BLOCKLIST_FILE` | Path to domain blocklist file. |
 | `INTENT_FILE` | Path to query intent configuration. |
 | `CLEAR_CACHE` | Clear `.cache` on start when set to `1`. |
+| `FORCE_ENGLISH_QUERIES` | Force query builder to emit ASCII-only queries (default `1`). |
+| `CACHE_BURST_THRESHOLD` | Cache hit ratio triggering temporary cache bypass (default `0.5`). |
+| `SEARCH_RADIUS_KM` | Base radius in kilometres for nearby city expansion (default `25`). |
 
 These options allow customising search behaviour without modifying the code.
 

--- a/crawler/control.py
+++ b/crawler/control.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from collections import deque
+from typing import Deque, Tuple
+
+
+@dataclass
+class RunState:
+    """State tracker for a crawl run.
+
+    It keeps statistics required to decide rotation, phase escalation
+    and termination. The object itself is intentionally free of side
+    effects so that it can easily be unit-tested.
+    """
+
+    target: int
+    max_queries: int
+    max_rotations: int
+    skip_rotate_threshold: int
+    cache_burst_threshold: float = 0.5
+    added: int = 0
+    queries: int = 0
+    rotations: int = 0
+    consecutive_skips: int = 0
+    phase: int = 1
+    _last_added: int = 0
+    recent_cache: Deque[int] = field(default_factory=lambda: deque(maxlen=20))
+    cache_burst: bool = False
+
+    def record_skip(self, reason: str) -> None:
+        """Record a skip and update cache statistics."""
+        self.consecutive_skips += 1
+        if reason == "cache-hit":
+            self.recent_cache.append(1)
+        else:
+            self.recent_cache.append(0)
+        if self.recent_cache:
+            ratio = sum(self.recent_cache) / len(self.recent_cache)
+            self.cache_burst = (
+                ratio >= self.cache_burst_threshold and self.added < self.target
+            )
+        else:
+            self.cache_burst = False
+
+    def record_add(self) -> None:
+        """Record a successful add and reset counters."""
+        self.added += 1
+        self.consecutive_skips = 0
+        self.recent_cache.clear()
+        self.cache_burst = False
+        self._last_added = self.added
+        self.phase = 1
+
+    def should_rotate(self) -> bool:
+        """Return ``True`` when a rotation should occur."""
+        if self.consecutive_skips >= self.skip_rotate_threshold:
+            self.consecutive_skips = 0
+            if self.rotations < self.max_rotations:
+                self.rotations += 1
+                return True
+        return False
+
+    def escalate_phase(self) -> int:
+        """Advance to the next escalation phase."""
+        if self.added > self._last_added:
+            self._last_added = self.added
+            self.phase = 1
+        else:
+            self.phase = min(self.phase + 1, 6)
+        return self.phase
+
+    def should_stop(
+        self,
+        *,
+        no_candidates: bool = False,
+        fatal_error: str | None = None,
+    ) -> Tuple[bool, str]:
+        """Determine whether the crawl should terminate."""
+        if self.added >= self.target:
+            return True, "target_met"
+        if self.queries >= self.max_queries:
+            return True, "max_queries"
+        if fatal_error:
+            return True, fatal_error
+        if no_candidates:
+            return True, "no_candidates"
+        return False, ""
+
+
+def format_stop(reason: str, state: RunState) -> str:
+    """Create a unified stop log message."""
+    return (
+        f"[STOP] reason={reason} added={state.added}/{state.target} "
+        f"rotations={state.rotations}/{state.max_rotations} "
+        f"queries={state.queries}/{state.max_queries}"
+    )
+
+
+__all__ = ["RunState", "format_stop"]

--- a/test_pipeline_smart_entrypoint.py
+++ b/test_pipeline_smart_entrypoint.py
@@ -112,7 +112,7 @@ def test_pipeline_smart_entrypoint(tmp_path):
             "GOOGLE_API_KEY": "dummy",
             "GOOGLE_CX": "dummy",
             "SHEET_ID": "dummy",
-            "STATES": "",  # no queries -> quick exit
+            "MAX_QUERIES_PER_RUN": "1",  # quick exit
             "PYTHONPATH": str(repo_root),
         }
     )
@@ -125,5 +125,5 @@ def test_pipeline_smart_entrypoint(tmp_path):
         env=env,
     )
 
-    assert "[END]" in result.stdout
+    assert "[STOP]" in result.stdout
     assert result.returncode == 0

--- a/tests/test_runstate.py
+++ b/tests/test_runstate.py
@@ -1,0 +1,37 @@
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from crawler.control import RunState, format_stop
+
+
+def test_cache_hits_do_not_stop():
+    st = RunState(target=3, max_queries=10, max_rotations=2, skip_rotate_threshold=2, cache_burst_threshold=0.5)
+    for _ in range(5):
+        st.queries += 1
+        st.record_skip("cache-hit")
+        stop, _ = st.should_stop()
+        assert not stop
+    for _ in range(3):
+        st.record_add()
+    stop, reason = st.should_stop()
+    assert stop and reason == "target_met"
+
+
+def test_rotation_limit_soft():
+    st = RunState(target=3, max_queries=10, max_rotations=1, skip_rotate_threshold=2)
+    st.record_skip("cache-hit")
+    st.record_skip("cache-hit")
+    assert st.should_rotate() is True
+    st.record_skip("cache-hit")
+    st.record_skip("cache-hit")
+    assert st.should_rotate() is False
+    stop, _ = st.should_stop()
+    assert not stop
+
+
+def test_stop_message_format():
+    st = RunState(target=3, max_queries=10, max_rotations=4, skip_rotate_threshold=2)
+    st.queries = 5
+    st.added = 3
+    msg = format_stop("target_met", st)
+    assert msg == "[STOP] reason=target_met added=3/3 rotations=0/4 queries=5/10"


### PR DESCRIPTION
## Summary
- Introduce `RunState` helper with pure control logic and stop message formatter
- Enforce English-only query building with phase-based expansion and new env flags
- Refactor pipeline loop to use soft rotation, escalate phases, and emit `[STOP]` logs
- Document new environment variables and add tests for state logic and entrypoint

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b05a340dc48322a0ff67cd902712c8