### PR TITLE
feat: add cache namespaces and runtime blocklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,15 @@ intent terms and excludes common noise domains.  Configuration lives in
 | Variable | Description |
 | --- | --- |
 | `EXCLUDE_DOMAINS` | Comma-separated extra domains to block before fetching. |
-| `SKIP_ROTATE_THRESHOLD` | Consecutive skip count before query rotation (default 20). |
+| `EXCLUDE_DOMAINS_EXTRA` | Additional domains appended to the default blocklist. |
+| `CACHE_VERSION` | Cache namespace version prefix (default `v1`). |
+| `SKIP_ROTATE_THRESHOLD` | Consecutive skip count before query rotation (default 8). |
 | `MAX_ROTATIONS_PER_RUN` | Maximum number of query rotations per run (default 4). |
 | `CITY_SEEDS` | Optional comma-separated list of city, state pairs. |
 | `BLOCKLIST_FILE` | Path to domain blocklist file. |
 | `INTENT_FILE` | Path to query intent configuration. |
 | `CLEAR_CACHE` | Clear `.cache` on start when set to `1`. |
-| `FORCE_ENGLISH_QUERIES` | Force query builder to emit ASCII-only queries (default `1`). |
+| `FORCE_ENGLISH_QUERIES` | Force query builder to emit ASCII-only queries (default `0`). |
 | `CACHE_BURST_THRESHOLD` | Cache hit ratio triggering temporary cache bypass (default `0.5`). |
 | `SEARCH_RADIUS_KM` | Base radius in kilometres for nearby city expansion (default `25`). |
 

--- a/cache_utils.py
+++ b/cache_utils.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+import os, uuid, hashlib
+from dataclasses import dataclass
+
+@dataclass
+class EnvConfig:
+    CACHE_VERSION: str = os.getenv("CACHE_VERSION", "v1")
+    EXCLUDE_DOMAINS_EXTRA: str = os.getenv("EXCLUDE_DOMAINS_EXTRA", "")
+    FORCE_ENGLISH_QUERIES: int = int(os.getenv("FORCE_ENGLISH_QUERIES", "0"))
+    SKIP_ROTATE_THRESHOLD: int = int(os.getenv("SKIP_ROTATE_THRESHOLD", "8"))
+
+class Cache:
+    """Lightweight cache namespace helper."""
+    def __init__(self, env: EnvConfig | None = None, *, phase: int = 1, cache_bust: bool = False):
+        self.env = env or EnvConfig()
+        self.phase = phase
+        self._suffix = uuid.uuid4().hex[:8] if cache_bust else ""
+        self.visited_urls: set[str] = set()
+
+    def namespace(self) -> str:
+        ns = self.env.CACHE_VERSION
+        if self.phase >= 3:
+            ns = f"{ns}:p{self.phase}"
+        if self._suffix:
+            ns = f"{ns}:{self._suffix}"
+        return ns
+
+    def key(self, url: str) -> str:
+        h = hashlib.sha256(url.encode("utf-8")).hexdigest()
+        return f"{self.namespace()}:{h}"
+
+    def seen(self, url: str) -> bool:
+        k = self.key(url)
+        if k in self.visited_urls:
+            return True
+        self.visited_urls.add(k)
+        return False
+
+__all__ = ["EnvConfig", "Cache"]

--- a/config/domain_blocklist.txt
+++ b/config/domain_blocklist.txt
@@ -12,3 +12,8 @@ doordash.com
 eventbrite.com
 tiktok.com
 pinterest.com
+instagram.com
+reddit.com
+square.site
+olo.com
+orderexperience.net

--- a/runtime_blocklist.py
+++ b/runtime_blocklist.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+from urllib.parse import urlparse
+import re
+
+BAD_REASONS = {"blocked_or_empty", "no_html", "status_401", "status_403", "js_required"}
+
+class RuntimeBlockList:
+    """Track domains that repeatedly fail or block requests."""
+    def __init__(self) -> None:
+        self.counts: dict[str, int] = {}
+        self.blocked: set[str] = set()
+
+    def record(self, url: str, reason: str) -> None:
+        if reason not in BAD_REASONS:
+            return
+        host = urlparse(url).hostname or ""
+        c = self.counts.get(host, 0) + 1
+        self.counts[host] = c
+        if c >= 2:
+            self.blocked.add(host)
+
+    def is_blocked(self, url: str) -> bool:
+        host = urlparse(url).hostname or ""
+        return host in self.blocked
+
+def requires_js(html: str) -> bool:
+    """Heuristic to detect pages that require JS."""
+    if not html:
+        return False
+    total = len(html.encode("utf-8"))
+    if total >= 8 * 1024:
+        return False
+    script_bytes = sum(len(m.group(0)) for m in re.finditer(r"<script[^>]*>.*?</script>", html, re.I | re.S))
+    return script_bytes / total > 0.35
+
+__all__ = ["RuntimeBlockList", "requires_js", "BAD_REASONS"]

--- a/smart_search.py
+++ b/smart_search.py
@@ -15,7 +15,10 @@ class QueryBuilder:
         self.cities: List[str] = self.intent.get("seed_cities", [])
         self.city_idx = 0
         self.ctx_idx = 0
-        self.rotate_threshold = int(os.getenv("SKIP_ROTATE_THRESHOLD", rotate_threshold or 25))
+        if rotate_threshold is not None:
+            self.rotate_threshold = int(rotate_threshold)
+        else:
+            self.rotate_threshold = int(os.getenv("SKIP_ROTATE_THRESHOLD", 25))
         self.consec_skips = 0
 
     def _join_or(self, terms: List[str]) -> str:

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -83,5 +83,5 @@ ps.append_row_in_order = lambda sheet, ws, row: print('[WRITE]', row)
 ps.load_existing_keys = lambda sheet, ws: {'homes': set(), 'instas': set()}
 
 # 実行
-ps.main()
+ps.main([])
 print('SMOKE TEST OK')

--- a/tests/test_cache_namespace.py
+++ b/tests/test_cache_namespace.py
@@ -1,0 +1,14 @@
+import os, sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from cache_utils import EnvConfig, Cache
+
+def test_cache_namespace_changes():
+    os.environ["CACHE_VERSION"] = "v9"
+    env = EnvConfig()
+    c1 = Cache(env, phase=1)
+    c2 = Cache(env, phase=3)
+    assert env.CACHE_VERSION in c1.namespace()
+    assert c1.namespace() != c2.namespace()
+    c3 = Cache(env, phase=3, cache_bust=True)
+    c4 = Cache(env, phase=3, cache_bust=True)
+    assert c3.namespace() != c4.namespace()

--- a/tests/test_phase_rotation.py
+++ b/tests/test_phase_rotation.py
@@ -1,0 +1,26 @@
+import sys, os, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from crawler.control import RunState
+from cache_utils import EnvConfig, Cache
+
+
+def test_phase_and_namespace_rotation():
+    os.environ["SKIP_ROTATE_THRESHOLD"] = "8"
+    try:
+        env = EnvConfig()
+        state = RunState(target=1, max_queries=100, max_rotations=5, skip_rotate_threshold=env.SKIP_ROTATE_THRESHOLD)
+        cache1 = Cache(env, phase=state.phase)
+        for _ in range(env.SKIP_ROTATE_THRESHOLD):
+            state.record_skip("miss")
+        if state.should_rotate():
+            state.escalate_phase()
+        assert state.phase == 2
+        for _ in range(env.SKIP_ROTATE_THRESHOLD):
+            state.record_skip("miss")
+        if state.should_rotate():
+            state.escalate_phase()
+        assert state.phase == 3
+        cache3 = Cache(env, phase=state.phase)
+        assert cache1.namespace() != cache3.namespace()
+    finally:
+        del os.environ["SKIP_ROTATE_THRESHOLD"]

--- a/tests/test_pipeline_runtime_blocklist.py
+++ b/tests/test_pipeline_runtime_blocklist.py
@@ -1,0 +1,21 @@
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from runtime_blocklist import RuntimeBlockList, requires_js
+
+
+def test_runtime_blocklist_learns_domain():
+    rb = RuntimeBlockList()
+    url1 = "http://example.com/a"
+    url2 = "http://example.com/b"
+    rb.record(url1, "no_html")
+    assert not rb.is_blocked(url1)
+    rb.record(url2, "status_403")
+    assert rb.is_blocked(url1)
+    assert rb.is_blocked("http://example.com/c")
+    assert not rb.is_blocked("http://other.com")
+
+
+def test_requires_js_heuristic():
+    html = "<html>" + "<script>1</script>" * 200 + "</html>"
+    assert requires_js(html)
+    assert not requires_js("<html><body>hi</body></html>")

--- a/tests/test_query_builder.py
+++ b/tests/test_query_builder.py
@@ -1,14 +1,18 @@
-import sys, pathlib
+import sys, pathlib, os
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 from crawler.query_builder import QueryBuilder
 
 
 def test_queries_ascii_and_blocklist():
-    qb = QueryBuilder(blocklist=["facebook.com", "mapquest.com"])
+    os.environ["FORCE_ENGLISH_QUERIES"] = "1"
+    os.environ["EXCLUDE_DOMAINS"] = "facebook.com"
+    os.environ["EXCLUDE_DOMAINS_EXTRA"] = "instagram.com"
+    qb = QueryBuilder(blocklist=["mapquest.com"])
     queries = qb.build_queries()
     assert 8 <= len(queries) <= 12
     assert any("-site:facebook.com" in q for q in queries)
+    assert any("-site:instagram.com" in q for q in queries)
     for q in queries:
         q.encode("ascii")
         assert len(q) <= 256


### PR DESCRIPTION
## Summary
- add phase-aware cache namespaces with optional cache busting
- skip repetitive failures via runtime domain blocklist
- expand query builder domain exclusions and english mode control

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b063d0cb5083228d8c160b08c311ef