### PR TITLE
feat: add matcha finder scaffold

### DIFF
--- a/.github/workflows/matcha.yml
+++ b/.github/workflows/matcha.yml
@@ -1,0 +1,58 @@
+name: Matcha daily
+on:
+  schedule:
+    - cron: "27 1 * * *"
+  workflow_dispatch: {}
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: matcha-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install deps
+        run: python -m pip install -r requirements.txt
+
+      - name: Read countries
+        id: list
+        run: echo "list=$(tr '\n' ',' < data/countries.txt)" >> $GITHUB_OUTPUT
+
+      - name: Process countries
+        continue-on-error: true
+        env:
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GOOGLE_CX: ${{ secrets.GOOGLE_CX }}
+          SEARCH_BUDGET: ${{ secrets.SEARCH_BUDGET }}
+        run: |
+          set -e
+          IFS=',' read -ra CS <<< "${{ steps.list.outputs.list }}"
+          for C in "${CS[@]}"; do
+            [ -z "$C" ] && continue
+            echo "=== $C ==="
+            python src/overpass_fetch.py --country "$C" --out "data/seeds_${C}.csv" || true
+            python src/verify_crawl.py --in "data/seeds_${C}.csv" --out "data/results_${C}.csv" || true
+            if [ -n "$GOOGLE_API_KEY" ] && [ -n "$GOOGLE_CX" ]; then
+              python src/fallback_search.py --country "$C" --budget "${SEARCH_BUDGET:-20}" || true
+            fi
+          done
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: results
+          path: data/*.csv
+
+      - name: Commit results back
+        if: github.ref == 'refs/heads/main'
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data/*.csv || true
+          git commit -m "chore: update results ($(date -u +'%Y-%m-%d'))" || exit 0
+          git push

--- a/data/countries.txt
+++ b/data/countries.txt
@@ -1,0 +1,6 @@
+US
+GB
+FR
+DE
+AU
+CA

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,3 @@
 requests
-python-dotenv
-playwright
 beautifulsoup4
 lxml
-rapidfuzz
-pytesseract
-Pillow
-PyPDF2
-gspread
-google-auth
-tqdm

--- a/src/fallback_search.py
+++ b/src/fallback_search.py
@@ -1,0 +1,130 @@
+import argparse
+import csv
+import logging
+import os
+import sys
+from typing import List
+from urllib.parse import urlparse
+
+import requests
+
+sys.path.append(os.path.dirname(__file__))
+from verify_crawl import analyze_site  # noqa: E402
+
+API_URL = "https://www.googleapis.com/customsearch/v1"
+OFFICIAL_TLDS = (
+    ".com",
+    ".co",
+    ".jp",
+    ".net",
+    ".org",
+    ".us",
+    ".uk",
+    ".ca",
+    ".au",
+    ".de",
+    ".fr",
+    ".it",
+    ".es",
+    ".pt",
+    ".kr",
+    ".cn",
+    ".tw",
+    ".th",
+)
+
+
+def search(query: str, key: str, cx: str) -> List[str]:
+    params = {"key": key, "cx": cx, "q": query}
+    delay = 1
+    for attempt in range(4):
+        try:
+            resp = requests.get(API_URL, params=params, timeout=30)
+            if resp.status_code == 200:
+                data = resp.json()
+                return [item.get("link") for item in data.get("items", [])]
+            if resp.status_code in (429, 403) or resp.status_code >= 500 or "quota" in resp.text.lower():
+                logging.warning("Search error %s: %s", resp.status_code, resp.text[:200])
+                time.sleep(delay)
+                delay *= 2
+                continue
+            logging.warning("Search unexpected status %s", resp.status_code)
+            return []
+        except requests.RequestException as exc:
+            logging.warning("Search exception: %s", exc)
+            time.sleep(delay)
+            delay *= 2
+    logging.info("Quota or persistent error, stopping search")
+    return []
+
+
+def pick_official(links: List[str]) -> str:
+    for link in links:
+        if link and urlparse(link).netloc.endswith(OFFICIAL_TLDS):
+            return link
+    return ""
+
+
+def save_rows(path: str, rows: List[dict]):
+    fieldnames = list(rows[0].keys()) if rows else []
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Fallback search for missing sites")
+    parser.add_argument("--country", required=True, help="ISO2 country code")
+    parser.add_argument("--in", dest="infile", help="Input results CSV", default=None)
+    parser.add_argument("--out", dest="outfile", help="Output results CSV", default=None)
+    parser.add_argument("--budget", type=int, default=None, help="Search budget")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    key = os.getenv("GOOGLE_API_KEY", "")
+    cx = os.getenv("GOOGLE_CX", "")
+    if not key or not cx:
+        logging.info("Google API key or CX missing, skipping search")
+        return
+
+    infile = args.infile or f"data/results_{args.country}.csv"
+    outfile = args.outfile or infile
+    budget = args.budget if args.budget is not None else int(os.getenv("SEARCH_BUDGET", "20"))
+
+    with open(infile, newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+
+    for row in rows:
+        if budget <= 0:
+            logging.info("Search budget exhausted")
+            break
+        if row.get("site"):
+            continue
+        query = f"{row.get('name', '')} {row.get('city', '')} official site"
+        links = search(query, key, cx)
+        if not links:
+            continue
+        site = pick_official(links[:3])
+        if not site:
+            continue
+        info = analyze_site(site)
+        row.update({
+            "site": info["site"],
+            "has_matcha": str(info["has_matcha"]).lower(),
+            "evidence_url": info["evidence_url"],
+            "instagram": info["instagram"],
+            "contact_email": info["contact_email"],
+            "contact_form": info["contact_form"],
+        })
+        save_rows(outfile, rows)
+        budget -= 1
+    save_rows(outfile, rows)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(1)

--- a/src/overpass_fetch.py
+++ b/src/overpass_fetch.py
@@ -1,0 +1,86 @@
+import argparse
+import csv
+import logging
+import sys
+import time
+from typing import Dict
+
+import requests
+
+API_URL = "https://overpass-api.de/api/interpreter"
+HEADERS = {"User-Agent": "matcha-finder/0.1 (+https://example.com)"}
+
+
+def fetch(country: str) -> Dict:
+    query = f"""
+    [out:json][timeout:60];
+    area["ISO3166-1"="{country}"][admin_level=2];
+    (
+      node["amenity"="cafe"](area);
+      node["shop"="tea"](area);
+      way["amenity"="cafe"](area);
+      way["shop"="tea"](area);
+    );
+    out center tags;
+    """
+    delay = 1
+    for attempt in range(3):
+        try:
+            logging.info("Querying Overpass for %s (attempt %s)", country, attempt + 1)
+            resp = requests.post(API_URL, data={"data": query}, headers=HEADERS, timeout=120)
+            if resp.status_code == 200:
+                time.sleep(1)
+                return resp.json()
+            logging.warning("Overpass status %s", resp.status_code)
+        except requests.RequestException as exc:
+            logging.warning("Overpass error: %s", exc)
+        time.sleep(delay)
+        delay *= 2
+    return {"elements": []}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Fetch cafe websites from Overpass")
+    parser.add_argument("--country", required=True, help="ISO2 country code")
+    parser.add_argument("--out", required=True, help="Output CSV path")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    data = fetch(args.country)
+    elements = data.get("elements", [])
+    logging.info("Fetched %d elements", len(elements))
+
+    with open(args.out, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow([
+            "id",
+            "name",
+            "addr:city",
+            "addr:country",
+            "website",
+            "contact:website",
+            "contact:instagram",
+            "contact:email",
+        ])
+        for el in elements:
+            tags = el.get("tags", {})
+            row = [
+                el.get("id", ""),
+                tags.get("name", ""),
+                tags.get("addr:city", ""),
+                tags.get("addr:country", ""),
+                tags.get("website", ""),
+                tags.get("contact:website", ""),
+                tags.get("contact:instagram", ""),
+                tags.get("contact:email", ""),
+            ]
+            writer.writerow(row)
+    logging.info("Wrote %s", args.out)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(1)

--- a/src/verify_crawl.py
+++ b/src/verify_crawl.py
@@ -1,0 +1,160 @@
+import argparse
+import csv
+import logging
+import sys
+import time
+from urllib.parse import urljoin, urlparse
+import requests
+
+from bs4 import BeautifulSoup
+
+TIMEOUT = 15
+HEADERS = {"User-Agent": "Mozilla/5.0 (matcha-finder; +https://example.com)"}
+MATCHA_WORDS = [
+    "matcha",
+    "抹茶",
+    "matcha latte",
+    "iced matcha",
+    "ceremonial matcha",
+    "thé matcha",
+    "latte matcha",
+    "té matcha",
+    "latte de matcha",
+    "tè matcha",
+    "tè al matcha",
+    "chá matcha",
+    "café matcha",
+    "말차",
+    "말차라떼",
+    "抹茶拿铁",
+    "抹茶牛奶",
+    "ชาเขียวมัทฉะ",
+    "มัทฉะ",
+]
+CONTACT_PATHS = [
+    "contact",
+    "contact-us",
+    "kontakt",
+    "contacto",
+    "联系我们",
+    "聯絡我們",
+    "お問い合わせ",
+]
+CANDIDATE_PATHS = ["/", "/menu", "/drinks", "/tea"] + [f"/{p}" for p in CONTACT_PATHS]
+
+
+def fetch(url: str):
+    delay = 1
+    for attempt in range(2):
+        try:
+            resp = requests.get(url, headers=HEADERS, timeout=TIMEOUT)
+            return resp
+        except requests.RequestException as exc:
+            logging.warning("Fetch error %s on %s", exc, url)
+            time.sleep(delay)
+            delay *= 2
+    return None
+
+
+def extract_instagram(soup: BeautifulSoup) -> str:
+    link = soup.find("a", href=lambda h: h and "instagram.com" in h)
+    if link and link.get("href"):
+        return link["href"]
+    link = soup.find("link", rel=lambda r: r and "me" in r, href=lambda h: h and "instagram.com" in h)
+    if link and link.get("href"):
+        return link["href"]
+    return ""
+
+
+def extract_email(soup: BeautifulSoup) -> str:
+    link = soup.find("a", href=lambda h: h and h.startswith("mailto:"))
+    if link and link.get("href"):
+        return link["href"].split(":", 1)[1]
+    return ""
+
+
+def analyze_site(site: str) -> dict:
+    if not site:
+        return {"site": "", "has_matcha": False, "evidence_url": "", "instagram": "", "contact_email": "", "contact_form": ""}
+    if not site.startswith("http"):
+        site = "http://" + site
+    parsed = urlparse(site)
+    base = f"{parsed.scheme}://{parsed.netloc}"
+    result = {"site": base, "has_matcha": False, "evidence_url": "", "instagram": "", "contact_email": "", "contact_form": ""}
+    for path in CANDIDATE_PATHS:
+        url = urljoin(base, path)
+        resp = fetch(url)
+        if not resp or resp.status_code >= 400:
+            continue
+        soup = BeautifulSoup(resp.text, "lxml")
+        text = soup.get_text(" ").lower()
+        if not result["instagram"]:
+            result["instagram"] = extract_instagram(soup)
+        if not result["contact_email"]:
+            result["contact_email"] = extract_email(soup)
+        if not result["contact_form"] and any(cp in path for cp in CONTACT_PATHS):
+            result["contact_form"] = url
+        if not result["has_matcha"]:
+            for kw in MATCHA_WORDS:
+                if kw.lower() in text:
+                    result["has_matcha"] = True
+                    result["evidence_url"] = url
+                    break
+        if result["has_matcha"] and result["instagram"] and result["contact_email"] and result["contact_form"]:
+            break
+    time.sleep(0.3)
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Verify cafe sites for matcha and contacts")
+    parser.add_argument("--in", dest="infile", required=True, help="Input CSV path")
+    parser.add_argument("--out", dest="outfile", required=True, help="Output CSV path")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    with open(args.infile, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    results = []
+    for row in rows:
+        site = row.get("website") or row.get("contact:website") or row.get("site")
+        info = analyze_site(site)
+        results.append({
+            "source_id": row.get("id", ""),
+            "name": row.get("name", ""),
+            "city": row.get("addr:city", ""),
+            "country": row.get("addr:country", ""),
+            "site": info["site"],
+            "has_matcha": str(info["has_matcha"]).lower(),
+            "evidence_url": info["evidence_url"],
+            "instagram": info["instagram"],
+            "contact_email": info["contact_email"],
+            "contact_form": info["contact_form"],
+        })
+
+    with open(args.outfile, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=[
+            "source_id",
+            "name",
+            "city",
+            "country",
+            "site",
+            "has_matcha",
+            "evidence_url",
+            "instagram",
+            "contact_email",
+            "contact_form",
+        ])
+        writer.writeheader()
+        writer.writerows(results)
+    logging.info("Wrote %s", args.outfile)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(1)


### PR DESCRIPTION
## Summary
- fetch cafe websites per country from Overpass
- crawl sites for matcha terms, Instagram and contacts
- optional Google CSE fallback with daily budget
- run everything daily via GitHub Actions workflow

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b272abca8483229815beb4853657c4