### PR TITLE
Add sheet contact updater and expand headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,21 @@ export GOOGLE_CX=xxxx
 python src/fallback_search.py --country US --budget 10
 ```
 
+### Update contacts from an existing sheet
+
+If a spreadsheet already contains home page URLs in column C, populate
+contact fields for each entry:
+
+```bash
+export SHEET_ID=xxxx              # target spreadsheet
+export ACTION_ROW=2               # starting row (default 2)
+python update_contact_info.py
+```
+
+Column D will be filled with Instagram links, column E with contact
+emails and column F with contact form URLs. When none of these are
+found, column G is set to `"なし"`.
+
 ## GitHub Actions
 
 The workflow in `.github/workflows/matcha.yml` runs daily and on manual dispatch. It processes each country, uploads `data/*.csv` as artifacts and, when running on `main`, commits updated results.

--- a/matcha-finder-share/set_header.py
+++ b/matcha-finder-share/set_header.py
@@ -6,5 +6,5 @@ scopes=["https://www.googleapis.com/auth/spreadsheets"]
 creds=Credentials.from_service_account_file("service_account.json", scopes=scopes)
 gc=gspread.authorize(creds)
 ws=gc.open_by_key(os.environ["SHEET_ID"]).worksheet("リスト")
-ws.update("A1:F1", [["店名","国","公式サイトURL","Instagramリンク","問い合わせアドレス","問い合わせフォームURL"]])
+ws.update("A1:G1", [["店名","国","公式サイトURL","Instagramリンク","問い合わせアドレス","問い合わせフォームURL","備考"]])
 print("ヘッダーを更新しました")

--- a/matcha-finder-share/sheet_io.py
+++ b/matcha-finder-share/sheet_io.py
@@ -4,7 +4,7 @@ import gspread
 from google.oauth2.service_account import Credentials
 from rules import normalize_url
 
-HEADERS = ["店名","国","公式サイトURL","問い合わせアドレス","問い合わせフォームURL","Instagramリンク"]
+HEADERS = ["店名","国","公式サイトURL","Instagramリンク","問い合わせアドレス","問い合わせフォームURL","備考"]
 
 def open_sheet():
     scopes = ['https://www.googleapis.com/auth/spreadsheets']

--- a/set_header.py
+++ b/set_header.py
@@ -6,5 +6,5 @@ scopes=["https://www.googleapis.com/auth/spreadsheets"]
 creds=Credentials.from_service_account_file("service_account.json", scopes=scopes)
 gc=gspread.authorize(creds)
 ws=gc.open_by_key(os.environ["SHEET_ID"]).worksheet("リスト")
-ws.update("A1:F1", [["店名","国","公式サイトURL","Instagramリンク","問い合わせアドレス","問い合わせフォームURL"]])
+ws.update("A1:G1", [["店名","国","公式サイトURL","Instagramリンク","問い合わせアドレス","問い合わせフォームURL","備考"]])
 print("ヘッダーを更新しました")

--- a/sheet_io.py
+++ b/sheet_io.py
@@ -4,7 +4,7 @@ import gspread
 from google.oauth2.service_account import Credentials
 from rules import normalize_url
 
-HEADERS = ["店名","国","公式サイトURL","問い合わせアドレス","問い合わせフォームURL","Instagramリンク"]
+HEADERS = ["店名","国","公式サイトURL","Instagramリンク","問い合わせアドレス","問い合わせフォームURL","備考"]
 
 def open_sheet():
     scopes = ['https://www.googleapis.com/auth/spreadsheets']

--- a/sheet_io_v2.py
+++ b/sheet_io_v2.py
@@ -2,7 +2,7 @@
 from gspread.exceptions import WorksheetNotFound
 from urllib.parse import urlsplit, urlunsplit
 
-ORDER = ["店名","国","公式サイトURL","Instagramリンク","問い合わせアドレス","問い合わせフォームURL"]
+ORDER = ["店名","国","公式サイトURL","Instagramリンク","問い合わせアドレス","問い合わせフォームURL","備考"]
 
 # ヘッダーには一切触れない。存在しなければワークシートを作るだけ。
 def _open_ws(sheet_id, worksheet_name):
@@ -12,7 +12,7 @@ def _open_ws(sheet_id, worksheet_name):
     try:
         ws = sh.worksheet(worksheet_name)
     except WorksheetNotFound:
-        ws = sh.add_worksheet(title=worksheet_name, rows=2000, cols=max(6, len(ORDER)))
+        ws = sh.add_worksheet(title=worksheet_name, rows=2000, cols=max(7, len(ORDER)))
     return ws
 
 def _canon_root(u: str) -> str:

--- a/update_contact_info.py
+++ b/update_contact_info.py
@@ -1,0 +1,40 @@
+import os
+import gspread
+from google.oauth2.service_account import Credentials
+from light_extract import http_get, extract_contacts
+
+def open_ws():
+    scopes = ["https://www.googleapis.com/auth/spreadsheets"]
+    creds = Credentials.from_service_account_file("service_account.json", scopes=scopes)
+    gc = gspread.authorize(creds)
+    sh = gc.open_by_key(os.environ["SHEET_ID"])
+    ws = sh.worksheet(os.environ.get("GOOGLE_WORKSHEET_NAME", "抹茶営業リスト（カフェ）"))
+    return ws
+
+def update_contacts(start_row: int = 2):
+    ws = open_ws()
+    values = ws.get_all_values()
+    if start_row < 2:
+        start_row = 2
+    for idx in range(start_row-1, len(values)):
+        row_num = idx + 1
+        row = values[idx]
+        home = row[2].strip() if len(row) > 2 else ""
+        if not home:
+            continue
+        resp = http_get(home)
+        if not resp or not resp.text:
+            continue
+        ig, emails, form = extract_contacts(home, resp.text)
+        email = emails[0] if emails else ""
+        updates = [{"range": f"D{row_num}:F{row_num}", "values": [[ig, email, form]]}]
+        note = "なし" if not ig and not email and not form else ""
+        updates.append({"range": f"G{row_num}", "values": [[note]]})
+        ws.batch_update(updates, value_input_option="RAW")
+
+def main():
+    start = int(os.getenv("ACTION_ROW", "2"))
+    update_contacts(start)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `update_contact_info.py` to populate Instagram, email, and form from column C URLs
- expand sheet headers to include Instagram, contact email, form link, and note column
- document new script usage in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68baed60ec0483229660b656e3f89b83