### PR TITLE
Fix case-insensitive mailto link handling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 beautifulsoup4
 openpyxl
+pytest

--- a/tests/test_update_contact_info.py
+++ b/tests/test_update_contact_info.py
@@ -17,6 +17,12 @@ def test_find_email_from_mailto():
     assert uc.find_email(soup) == "info@example.com"
 
 
+def test_find_email_from_mailto_case_insensitive():
+    html = '<a href="MAILTO:INFO@EXAMPLE.COM?subject=test">mail</a>'
+    soup = BeautifulSoup(html, "html.parser")
+    assert uc.find_email(soup) == "INFO@EXAMPLE.COM"
+
+
 def test_find_contact_form():
     html = '<a href="/contact">contact</a>'
     soup = BeautifulSoup(html, "html.parser")

--- a/update_contact_info.py
+++ b/update_contact_info.py
@@ -15,9 +15,23 @@ def find_instagram(soup, base_url):
     return None
 
 def find_email(soup):
-    mailto = soup.select_one("a[href^=mailto]")
+    """Extract an email address from the page soup.
+
+    The previous implementation only matched ``mailto:`` links written in
+    lowercase.  Some sites, however, use capitalised schemes such as
+    ``MAILTO:`` which caused the function to miss valid e-mail addresses.
+
+    This version performs a case-insensitive search for ``mailto`` links and
+    strips the scheme in a case-insensitive manner as well.  If no explicit
+    ``mailto`` link is present, it falls back to searching the page text with
+    a regular expression.
+    """
+
+    mailto = soup.find("a", href=lambda h: h and h.lower().startswith("mailto:"))
     if mailto and mailto.get("href"):
-        return mailto["href"].split("mailto:")[-1].split("?")[0]
+        href = mailto["href"]
+        # Remove the leading scheme (case-insensitively) and any query string
+        return re.sub(r"^mailto:", "", href, flags=re.I).split("?")[0]
     match = EMAIL_RE.search(soup.get_text())
     if match:
         return match.group(0)


### PR DESCRIPTION
## Summary
- handle MAILTO links regardless of letter case in find_email
- test case-insensitive mailto parsing
- include pytest in requirements for CI

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68baf87fcee88322aad0d5e259123629