### PR TITLE
Enable row range selection in Matcha Contact Finder

### DIFF
--- a/.github/workflows/run-contact-finder.yml
+++ b/.github/workflows/run-contact-finder.yml
@@ -1,0 +1,23 @@
+name: Run Matcha Contact Finder
+
+on:
+  workflow_dispatch:
+    inputs:
+      sheet:
+        description: 'Path to Excel file to update'
+        required: true
+      start-row:
+        description: 'Row number to start processing'
+        required: true
+        default: '2'
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./
+        with:
+          sheet: ${{ inputs.sheet }}
+          start-row: ${{ inputs.start-row }}
+

--- a/README.md
+++ b/README.md
@@ -7,16 +7,16 @@
 - F列: 問い合わせフォームへのリンク
 - いずれも見つからない場合は G列に `なし` と記入
 
-開始行はコマンドライン引数 `--start-row` で指定するか、シートの `A1` に `Action`、`B1` に開始行番号を記載してください。
+開始行はコマンドライン引数 `--start-row` で指定するか、シートの `A1` に `Action`、`B1` に開始行番号を記載してください。終了行を限定したい場合は `--end-row` もしくは `C1` に終了行を指定できます。
 
 ## 使い方
 
 ```bash
 pip install -r requirements.txt  # 要 Python 3.11
-python update_contact_info.py sample.xlsx --start-row 2 --debug
+python update_contact_info.py sample.xlsx --start-row 2 --end-row 10 --debug
 ```
 
-`--debug` を付けると処理中の URL や失敗したリクエストがログに出力され、デバッグに便利です。このコマンドは `sample.xlsx` の 2 行目から処理を開始します。シート内に `Action` 行を用意している場合、`--start-row` は不要です。
+`--debug` を付けると処理中の URL や失敗したリクエストがログに出力され、デバッグに便利です。このコマンドは `sample.xlsx` の 2 行目から 10 行目まで処理します。シート内に `Action` 行を用意している場合、`--start-row` や `--end-row` は不要です。
 
 ## GitHub Actions での実行
 
@@ -53,6 +53,7 @@ jobs:
         with:
           sheet: path/to/file.xlsx
           start-row: 2
+          end-row: 10
           debug: true
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: 'Row number to start processing'
     required: false
     default: '2'
+  end-row:
+    description: 'Row number to stop processing (inclusive)'
+    required: false
+    default: ''
   debug:
     description: 'Enable debug logging'
     required: false
@@ -26,8 +30,11 @@ runs:
     - name: Run update_contact_info
       shell: bash
       run: |
-        if [ "${{ inputs.debug }}" = "true" ]; then
-          python update_contact_info.py "${{ inputs.sheet }}" --start-row "${{ inputs.start-row }}" --debug
-        else
-          python update_contact_info.py "${{ inputs.sheet }}" --start-row "${{ inputs.start-row }}"
+        cmd="python update_contact_info.py \"${{ inputs.sheet }}\" --start-row \"${{ inputs.start-row }}\""
+        if [ -n "${{ inputs.end-row }}" ]; then
+          cmd="$cmd --end-row \"${{ inputs.end-row }}\""
         fi
+        if [ "${{ inputs.debug }}" = "true" ]; then
+          cmd="$cmd --debug"
+        fi
+        eval $cmd

--- a/tests/test_update_contact_info.py
+++ b/tests/test_update_contact_info.py
@@ -27,3 +27,28 @@ def test_find_contact_form():
     html = '<a href="/contact">contact</a>'
     soup = BeautifulSoup(html, "html.parser")
     assert uc.find_contact_form(soup, "http://example.com") == "http://example.com/contact"
+
+
+def test_process_sheet_row_range(tmp_path, monkeypatch):
+    import openpyxl
+
+    class DummyResponse:
+        text = "<html></html>"
+
+    def dummy_get(url, timeout):
+        return DummyResponse()
+
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.cell(row=2, column=3, value="http://a")
+    ws.cell(row=3, column=3, value="http://b")
+    file = tmp_path / "sample.xlsx"
+    wb.save(file)
+
+    monkeypatch.setattr(uc.requests, "get", dummy_get)
+    uc.process_sheet(str(file), start_row=2, end_row=2)
+
+    wb2 = openpyxl.load_workbook(file)
+    ws2 = wb2.active
+    assert ws2.cell(row=2, column=7).value == "なし"
+    assert ws2.cell(row=3, column=7).value is None

--- a/update_contact_info.py
+++ b/update_contact_info.py
@@ -47,7 +47,7 @@ def find_contact_form(soup, base_url):
             return href if href.startswith("http") else urljoin(base_url, href)
     return None
 
-def process_sheet(path, start_row=None, debug=False):
+def process_sheet(path, start_row=None, end_row=None, debug=False):
     import openpyxl
 
     if debug:
@@ -55,15 +55,30 @@ def process_sheet(path, start_row=None, debug=False):
 
     wb = openpyxl.load_workbook(path)
     ws = wb.active
-    if start_row is None:
+
+    # Determine start and end rows. They can be provided via arguments or
+    # specified in the sheet's first row as ``Action`` metadata.
+    if start_row is None or end_row is None:
         if ws["A1"].value == "Action":
-            try:
-                start_row = int(ws["B1"].value)
-            except (TypeError, ValueError):
-                start_row = 2
+            if start_row is None:
+                try:
+                    start_row = int(ws["B1"].value)
+                except (TypeError, ValueError):
+                    start_row = 2
+            if end_row is None:
+                try:
+                    end_row = int(ws["C1"].value)
+                except (TypeError, ValueError):
+                    end_row = ws.max_row
         else:
-            start_row = 2
-    for row in range(start_row, ws.max_row + 1):
+            if start_row is None:
+                start_row = 2
+            if end_row is None:
+                end_row = ws.max_row
+
+    end_row = min(end_row, ws.max_row)
+
+    for row in range(start_row, end_row + 1):
         url = ws.cell(row=row, column=3).value
         if not url:
             continue
@@ -92,9 +107,10 @@ def main():
     parser = argparse.ArgumentParser(description="Update contact info from homepage URLs.")
     parser.add_argument("sheet", help="Path to Excel file to update")
     parser.add_argument("--start-row", type=int, default=None, help="Row number to start processing")
+    parser.add_argument("--end-row", type=int, default=None, help="Row number to stop processing (inclusive)")
     parser.add_argument("--debug", action="store_true", help="Enable debug logging")
     args = parser.parse_args()
-    process_sheet(args.sheet, args.start_row, args.debug)
+    process_sheet(args.sheet, args.start_row, args.end_row, args.debug)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- allow processing a specific range of rows in `update_contact_info.py`
- add `end-row` option to GitHub Action and documentation
- cover row range behavior with tests
- expose a manual workflow so the starting row can be chosen from the Actions tab

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb9e0ff93c8322988de2f6ff1db6ff