### PR TITLE
Stop on blank column A and fix sheet path

### DIFF
--- a/.github/workflows/run-contact-finder.yml
+++ b/.github/workflows/run-contact-finder.yml
@@ -3,9 +3,6 @@ name: Run Matcha Contact Finder
 on:
   workflow_dispatch:
     inputs:
-      sheet:
-        description: 'Path to Excel file to update'
-        required: true
       start-row:
         description: 'Row number to start processing'
         required: false
@@ -29,7 +26,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./
         with:
-          sheet: ${{ inputs.sheet }}
           start-row: ${{ inputs['start-row'] }}
           end-row: ${{ inputs['end-row'] }}
           worksheet-name: ${{ inputs['worksheet-name'] }}

--- a/README.md
+++ b/README.md
@@ -7,11 +7,18 @@
 - F列: 問い合わせフォームへのリンク
 - いずれも見つからない場合は G列に `なし` と記入
 
-開始行はコマンドライン引数 `--start-row` で指定するか、シートの `A1` に `Action`、`B1` に開始行番号を記載してください。指定がない場合は 2 行目から開始されます。終了行を限定したい場合は `--end-row` もしくは `C1` に終了行を指定できます。  
+GitHub Action は以下の Google スプレッドシートを対象とし、A 列が空欄の行で処理を終了します。
+https://docs.google.com/spreadsheets/d/1HU-GqN7sBcORIZrYEw4FkyfNmgDtXsO7CtDLVHEsldA/edit?gid=159511499#gid=159511499
+
+開始行はコマンドライン引数 `--start-row` で指定するか、シートの `A1` に `Action`、`B1` に開始行番号を記載してください。指定がない場合は 2 行目から開始されます。終了行を限定したい場合は `--end-row` もしくは `C1` に終了行を指定できます。
 デフォルトではシート名「抹茶営業リスト（カフェ）」を処理しますが、`--worksheet` 引数または GitHub Action の `worksheet-name` で別のシートを指定できます。
 
 ## 使い方
 
 ```bash
 pip install -r requirements.txt  # 要 Python 3.11
-python update_contact_info.py sample.xlsx --start-row 2 --end-row 10 --worksheet 'Sheet1' --debug
+# デフォルトのスプレッドシートを更新
+python update_contact_info.py --start-row 2 --end-row 10 --worksheet 'Sheet1' --debug
+# 別のファイルを処理したい場合はパスを指定
+# python update_contact_info.py sample.xlsx --start-row 2 --end-row 10 --worksheet 'Sheet1' --debug
+```

--- a/action.yml
+++ b/action.yml
@@ -3,9 +3,6 @@ description: 'Update Excel with contact info found from website URLs'
 author: 'auto-generated'
 
 inputs:
-  sheet:
-    description: 'Path to Excel file to update'
-    required: true
   start-row:
     description: 'Row number to start processing'
     required: false
@@ -38,7 +35,7 @@ runs:
     - name: Run update_contact_info
       shell: bash
       run: |
-        cmd="python update_contact_info.py \"${{ inputs.sheet }}\" --start-row \"${{ inputs['start-row'] }}\" --worksheet \"${{ inputs['worksheet-name'] }}\""
+        cmd="python update_contact_info.py --start-row \"${{ inputs['start-row'] }}\" --worksheet \"${{ inputs['worksheet-name'] }}\""
         if [ -n "${{ inputs['end-row'] }}" ]; then
           cmd="$cmd --end-row \"${{ inputs['end-row'] }}\""
         fi

--- a/tests/test_update_contact_info.py
+++ b/tests/test_update_contact_info.py
@@ -42,6 +42,7 @@ def test_process_sheet_row_range(tmp_path, monkeypatch):
     wb = openpyxl.Workbook()
     ws = wb.active
     ws.title = "Sheet"
+    ws.cell(row=2, column=1, value="ok")
     ws.cell(row=2, column=3, value="http://a")
     ws.cell(row=3, column=3, value="http://b")
     file = tmp_path / "sample.xlsx"
@@ -68,8 +69,10 @@ def test_process_specific_worksheet(tmp_path, monkeypatch):
     wb = openpyxl.Workbook()
     ws1 = wb.active
     ws1.title = "Sheet1"
+    ws1.cell(row=2, column=1, value="ok")
     ws1.cell(row=2, column=3, value="http://a")
     ws2 = wb.create_sheet("Sheet2")
+    ws2.cell(row=2, column=1, value="ok")
     ws2.cell(row=2, column=3, value="http://b")
     file = tmp_path / "sample.xlsx"
     wb.save(file)
@@ -80,3 +83,33 @@ def test_process_specific_worksheet(tmp_path, monkeypatch):
     wb2 = openpyxl.load_workbook(file)
     assert wb2["Sheet1"].cell(row=2, column=7).value is None
     assert wb2["Sheet2"].cell(row=2, column=7).value == "なし"
+
+
+def test_stop_on_blank_column_a(tmp_path, monkeypatch):
+    import openpyxl
+
+    class DummyResponse:
+        text = "<html></html>"
+
+    def dummy_get(url, timeout):
+        return DummyResponse()
+
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "Sheet"
+    ws.cell(row=2, column=1, value="ok")
+    ws.cell(row=2, column=3, value="http://a")
+    ws.cell(row=3, column=3, value="http://b")  # A3 is blank
+    ws.cell(row=4, column=1, value="ok")
+    ws.cell(row=4, column=3, value="http://c")
+    file = tmp_path / "sample.xlsx"
+    wb.save(file)
+
+    monkeypatch.setattr(uc.requests, "get", dummy_get)
+    uc.process_sheet(str(file), start_row=2, worksheet="Sheet")
+
+    wb2 = openpyxl.load_workbook(file)
+    ws2 = wb2["Sheet"]
+    assert ws2.cell(row=2, column=7).value == "なし"
+    assert ws2.cell(row=3, column=7).value is None
+    assert ws2.cell(row=4, column=7).value is None

--- a/update_contact_info.py
+++ b/update_contact_info.py
@@ -8,6 +8,11 @@ from bs4 import BeautifulSoup
 
 EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
 
+DEFAULT_SHEET_PATH = (
+    "https://docs.google.com/spreadsheets/d/1HU-GqN7sBcORIZrYEw4FkyfNmgDtXsO7CtDLVHEsldA/"
+    "edit?gid=159511499#gid=159511499"
+)
+
 
 def find_instagram(soup, base_url):
     for a in soup.find_all("a", href=True):
@@ -82,6 +87,8 @@ def process_sheet(path, start_row=None, end_row=None, worksheet="抹茶営業リ
     end_row = min(end_row, ws.max_row)
 
     for row in range(start_row, end_row + 1):
+        if not ws.cell(row=row, column=1).value:
+            break
         url = ws.cell(row=row, column=3).value
         if not url:
             continue
@@ -112,7 +119,12 @@ def process_sheet(path, start_row=None, end_row=None, worksheet="抹茶営業リ
 
 def main():
     parser = argparse.ArgumentParser(description="Update contact info from homepage URLs.")
-    parser.add_argument("sheet", help="Path to Excel file to update")
+    parser.add_argument(
+        "sheet",
+        nargs="?",
+        default=DEFAULT_SHEET_PATH,
+        help="Path to Excel file to update",
+    )
     parser.add_argument("--start-row", type=int, default=None, help="Row number to start processing")
     parser.add_argument("--end-row", type=int, default=None, help="Row number to stop processing (inclusive)")
     parser.add_argument("--worksheet", default="抹茶営業リスト（カフェ）", help="Worksheet name to process")


### PR DESCRIPTION
## Summary
- Hardcode Google Sheets URL as default sheet path
- Halt processing when column A is blank
- Remove sheet path input from action and workflow
- Document fixed sheet and stopping behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc3c12c5e483228599affc22fc71f8