### PR TITLE
Simplify workflow to rely on start row only

### DIFF
--- a/.github/workflows/run-contact-finder.yml
+++ b/.github/workflows/run-contact-finder.yml
@@ -7,9 +7,6 @@ on:
         description: 'Row number to start processing'
         required: false
         default: '2'
-      end-row:
-        description: 'Row number to stop processing (inclusive)'
-        required: false
       worksheet-name:
         description: 'Worksheet name to process'
         required: false
@@ -27,6 +24,5 @@ jobs:
       - uses: ./
         with:
           start-row: ${{ inputs['start-row'] }}
-          end-row: ${{ inputs['end-row'] }}
           worksheet-name: ${{ inputs['worksheet-name'] }}
           debug: ${{ inputs.debug }}

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 GitHub Action は以下の Google スプレッドシートを対象とし、A 列が空欄の行で処理を終了します。
 https://docs.google.com/spreadsheets/d/1HU-GqN7sBcORIZrYEw4FkyfNmgDtXsO7CtDLVHEsldA/edit?gid=159511499#gid=159511499
 
-開始行はコマンドライン引数 `--start-row` で指定するか、シートの `A1` に `Action`、`B1` に開始行番号を記載してください。指定がない場合は 2 行目から開始されます。終了行を限定したい場合は `--end-row` もしくは `C1` に終了行を指定できます。
+開始行はコマンドライン引数 `--start-row` で指定するか、シートの `A1` に `Action`、`B1` に開始行番号を記載してください。指定がない場合は 2 行目から開始されます。終了行を限定したい場合は `--end-row` もしくは `C1` に終了行を指定できますが、GitHub Actions でワークフローを実行する場合は開始行のみを指定し、A 列が空欄の行で自動的に処理が止まります。
 デフォルトではシート名「抹茶営業リスト（カフェ）」を処理しますが、`--worksheet` 引数または GitHub Action の `worksheet-name` で別のシートを指定できます。
 
 ## 使い方

--- a/action.yml
+++ b/action.yml
@@ -7,10 +7,6 @@ inputs:
     description: 'Row number to start processing'
     required: false
     default: '2'
-  end-row:
-    description: 'Row number to stop processing (inclusive)'
-    required: false
-    default: ''
   worksheet-name:
     description: 'Worksheet name to process'
     required: false
@@ -36,9 +32,6 @@ runs:
       shell: bash
       run: |
         cmd="python update_contact_info.py --start-row \"${{ inputs['start-row'] }}\" --worksheet \"${{ inputs['worksheet-name'] }}\""
-        if [ -n "${{ inputs['end-row'] }}" ]; then
-          cmd="$cmd --end-row \"${{ inputs['end-row'] }}\""
-        fi
         if [ "${{ inputs.debug }}" = "true" ]; then
           cmd="$cmd --debug"
         fi


### PR DESCRIPTION
## Summary
- Remove `end-row` input from custom action and workflow dispatch
- Document that GitHub Actions run stops when column A is empty

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc458a17088322af118602e9d654b6