### PR TITLE
Handle SSL failures and mark unreachable sites

### DIFF
--- a/tests/test_update_contact_info.py
+++ b/tests/test_update_contact_info.py
@@ -115,6 +115,36 @@ def test_stop_on_blank_column_a(tmp_path, monkeypatch):
     assert ws2.cell(row=4, column=7).value is None
 
 
+def test_start_row_ignores_action_end(tmp_path, monkeypatch):
+    import openpyxl
+
+    class DummyResponse:
+        text = "<html></html>"
+
+    def dummy_get(url, timeout):
+        return DummyResponse()
+
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "Sheet"
+    ws.cell(row=1, column=1, value="Action")
+    ws.cell(row=1, column=3, value=2)  # would normally stop at row 2
+    ws.cell(row=2, column=1, value="ok")
+    ws.cell(row=2, column=3, value="http://a")
+    ws.cell(row=3, column=1, value="ok")
+    ws.cell(row=3, column=3, value="http://b")
+    file = tmp_path / "sample.xlsx"
+    wb.save(file)
+
+    monkeypatch.setattr(uc.requests, "get", dummy_get)
+    uc.process_sheet(str(file), start_row=2, worksheet="Sheet")
+
+    wb2 = openpyxl.load_workbook(file)
+    ws2 = wb2["Sheet"]
+    assert ws2.cell(row=2, column=7).value == "なし"
+    assert ws2.cell(row=3, column=7).value == "なし"
+
+
 def test_skip_invalid_url(tmp_path, monkeypatch):
     import openpyxl
 
@@ -221,3 +251,57 @@ def test_google_sheet_link_is_transformed(monkeypatch, tmp_path):
     wb2 = openpyxl.load_workbook(tmp_path / "downloaded.xlsx")
     ws2 = wb2["Sheet"]
     assert ws2.cell(row=2, column=7).value == "なし"
+
+
+def test_retry_on_ssl_error(tmp_path, monkeypatch):
+    import openpyxl
+    from requests.exceptions import SSLError
+
+    calls = []
+
+    def dummy_get(url, timeout, verify=True):
+        calls.append(verify)
+        if verify:
+            raise SSLError("bad cert")
+        class DummyResponse:
+            text = "<html></html>"
+        return DummyResponse()
+
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "Sheet"
+    ws.cell(row=2, column=1, value="ok")
+    ws.cell(row=2, column=3, value="https://a")
+    file = tmp_path / "sample.xlsx"
+    wb.save(file)
+
+    monkeypatch.setattr(uc.requests, "get", dummy_get)
+    uc.process_sheet(str(file), start_row=2, end_row=2, worksheet="Sheet")
+
+    assert calls == [True, False]
+    wb2 = openpyxl.load_workbook(file)
+    ws2 = wb2["Sheet"]
+    assert ws2.cell(row=2, column=7).value == "なし"
+
+
+def test_request_failure_marks_error(tmp_path, monkeypatch):
+    import openpyxl
+    from requests.exceptions import ConnectionError
+
+    def dummy_get(url, timeout, verify=True):
+        raise ConnectionError("fail")
+
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "Sheet"
+    ws.cell(row=2, column=1, value="ok")
+    ws.cell(row=2, column=3, value="https://a")
+    file = tmp_path / "sample.xlsx"
+    wb.save(file)
+
+    monkeypatch.setattr(uc.requests, "get", dummy_get)
+    uc.process_sheet(str(file), start_row=2, end_row=2, worksheet="Sheet")
+
+    wb2 = openpyxl.load_workbook(file)
+    ws2 = wb2["Sheet"]
+    assert ws2.cell(row=2, column=7).value == "エラー"

--- a/update_contact_info.py
+++ b/update_contact_info.py
@@ -87,25 +87,26 @@ def process_sheet(path, start_row=None, end_row=None, worksheet="抹茶営業リ
     wb = openpyxl.load_workbook(path)
     ws = wb[worksheet]
 
-    # Determine start and end rows. They can be provided via arguments or
-    # specified in the sheet's first row as ``Action`` metadata.
-    if start_row is None or end_row is None:
-        if ws["A1"].value == "Action":
-            if start_row is None:
-                try:
-                    start_row = int(ws["B1"].value)
-                except (TypeError, ValueError):
-                    start_row = 2
-            if end_row is None:
-                try:
-                    end_row = int(ws["C1"].value)
-                except (TypeError, ValueError):
-                    end_row = ws.max_row
-        else:
-            if start_row is None:
-                start_row = 2
-            if end_row is None:
-                end_row = ws.max_row
+    # Determine start and end rows.  If both are unspecified and the sheet
+    # contains ``Action`` metadata in the first row, honour those values.
+    # Otherwise, default to starting from row 2 and processing until the last
+    # row in the sheet.  This ensures that explicitly providing ``start_row``
+    # via the command line causes the script to keep scanning downward until
+    # column A becomes blank, regardless of any value in ``C1``.
+    if start_row is None and end_row is None and ws["A1"].value == "Action":
+        try:
+            start_row = int(ws["B1"].value)
+        except (TypeError, ValueError):
+            start_row = 2
+        try:
+            end_row = int(ws["C1"].value)
+        except (TypeError, ValueError):
+            end_row = ws.max_row
+    else:
+        if start_row is None:
+            start_row = 2
+        if end_row is None:
+            end_row = ws.max_row
 
     end_row = min(end_row, ws.max_row)
 
@@ -123,8 +124,18 @@ def process_sheet(path, start_row=None, end_row=None, worksheet="抹茶営業リ
         logging.info("Processing row %s: %s", row, url)
         try:
             res = requests.get(url, timeout=REQUEST_TIMEOUT)
+        except requests.exceptions.SSLError:
+            try:
+                res = requests.get(url, timeout=REQUEST_TIMEOUT, verify=False)
+            except requests.RequestException as e:
+                logging.warning(
+                    "Request failed for row %s (%s): %s", row, url, e
+                )
+                ws.cell(row=row, column=7).value = "エラー"
+                continue
         except requests.RequestException as e:
-            logging.warning("Request failed for %s: %s", url, e)
+            logging.warning("Request failed for row %s (%s): %s", row, url, e)
+            ws.cell(row=row, column=7).value = "エラー"
             continue
         soup = BeautifulSoup(res.text, "html.parser")
         insta = find_instagram(soup, url)


### PR DESCRIPTION
## Summary
- retry HTTP requests with `verify=False` when SSL certificate check fails
- log row number and mark sheet with `エラー` on request failure
- ignore Action end row when start row is given, scanning until column A is blank
- add tests for SSL retry, error marking, and start-row override

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd1f57ebe08322967b9082786d0168