### PR TITLE
feat: write contact info directly to Google Sheets

### DIFF
--- a/.github/workflows/run-contact-finder.yml
+++ b/.github/workflows/run-contact-finder.yml
@@ -1,4 +1,4 @@
-name: Run Matcha Contact Finder
+name: Run Matcha Contact Finder (Sheets API)
 
 on:
   workflow_dispatch:
@@ -6,23 +6,33 @@ on:
       start-row:
         description: 'Row number to start processing'
         required: false
-        default: '2'
+        default: '1508'
       worksheet-name:
-        description: 'Worksheet name to process'
+        description: 'Worksheet title'
         required: false
         default: '抹茶営業リスト（カフェ）'
-      debug:
-        description: 'Enable debug logging'
-        required: false
-        default: 'false'
 
 jobs:
   update:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ./
+
+      - uses: actions/setup-python@v5
         with:
-          start-row: ${{ inputs['start-row'] }}
-          worksheet-name: ${{ inputs['worksheet-name'] }}
-          debug: ${{ inputs.debug }}
+          python-version: '3.11'
+
+      - run: pip install -r requirements.txt
+
+      - name: Write service account key file
+        run: echo '${{ secrets.GOOGLE_CREDENTIALS }}' > sa.json
+
+      - name: Update contacts on Google Sheet
+        env:
+          SPREADSHEET_ID: ${{ secrets.SPREADSHEET_ID }}
+        run: |
+          python update_contact_info_api.py \
+            --spreadsheet-id "$SPREADSHEET_ID" \
+            --worksheet "${{ inputs['worksheet-name'] }}" \
+            --start-row "${{ inputs['start-row'] }}"
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ beautifulsoup4
 openpyxl
 pytest
 google-api-python-client
+google-auth
 google-auth-httplib2
 google-auth-oauthlib


### PR DESCRIPTION
## Summary
- rewrite API script to update Google Sheet rows directly using service account
- add GitHub workflow for running the contact finder against a sheet
- include google-auth dependency

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd30e023c48322973e5aca7b4eb689