### PR TITLE
Add secret checks and JSON validation for Sheets workflow

### DIFF
--- a/.github/workflows/run-contact-finder.yml
+++ b/.github/workflows/run-contact-finder.yml
@@ -24,9 +24,26 @@ jobs:
 
       - run: pip install -r requirements.txt
 
-      - name: Write service account key file
-        run: echo '${{ secrets.GOOGLE_CREDENTIALS }}' > sa.json
+      # 1) 必須Secretsの存在チェック
+      - name: Validate required secrets
+        run: |
+          [ -n "${{ secrets.GOOGLE_CREDENTIALS }}" ] || { echo "Missing secret: GOOGLE_CREDENTIALS"; exit 1; }
+          [ -n "${{ secrets.SPREADSHEET_ID }}" ] || { echo "Missing secret: SPREADSHEET_ID"; exit 1; }
 
+      # 2) sa.json を安全に作成し、JSON妥当性を検証
+      - name: Write and validate service account key
+        env:
+          GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
+        run: |
+          printf '%s' "$GOOGLE_CREDENTIALS" > sa.json
+          python - <<'PY'
+import json, sys
+with open('sa.json','r',encoding='utf-8') as f:
+    json.load(f)
+print("sa.json OK")
+PY
+
+      # 3) スクリプトを実行（SPREADSHEET_ID を env で注入）
       - name: Update contacts on Google Sheet
         env:
           SPREADSHEET_ID: ${{ secrets.SPREADSHEET_ID }}
@@ -35,4 +52,3 @@ jobs:
             --spreadsheet-id "$SPREADSHEET_ID" \
             --worksheet "${{ inputs['worksheet-name'] }}" \
             --start-row "${{ inputs['start-row'] }}"
-

--- a/update_contact_info_api.py
+++ b/update_contact_info_api.py
@@ -28,7 +28,9 @@ Example usage::
 from __future__ import annotations
 
 import argparse
+import json
 import logging
+import os
 from typing import Optional
 
 import requests
@@ -47,6 +49,14 @@ SCOPES = ["https://www.googleapis.com/auth/spreadsheets"]
 
 def _build_sheet_service(credentials_file: str) -> "Resource":
     """Return an authorised Sheets API client."""
+
+    if not os.path.exists(credentials_file):
+        raise SystemExit(f"Credentials file not found: {credentials_file}")
+    try:
+        with open(credentials_file, "r", encoding="utf-8") as f:
+            json.load(f)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Invalid service account JSON: {exc}")
 
     creds = service_account.Credentials.from_service_account_file(
         credentials_file, scopes=SCOPES
@@ -163,6 +173,9 @@ def main() -> None:  # pragma: no cover - CLI entry point
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    if not args.spreadsheet_id.strip():
+        parser.error("--spreadsheet-id must not be empty")
 
     process_sheet(
         spreadsheet_id=args.spreadsheet_id,


### PR DESCRIPTION
## Summary
- fail fast in workflow when required secrets are missing or invalid
- validate service account JSON and spreadsheet ID before updating sheet

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd330441448322931cbbc926507ad2