### PR TITLE
fix: enable manual contact finder workflow

### DIFF
--- a/.github/workflows/run-contact-finder.yml
+++ b/.github/workflows/run-contact-finder.yml
@@ -12,8 +12,7 @@ on:
         required: false
         default: '抹茶営業リスト（カフェ）'
   push:
-    branches:
-      - main
+    branches: [ main ]
 
 jobs:
   update:


### PR DESCRIPTION
## Summary
- ensure `run-contact-finder` workflow uses a single `on` block with manual and push triggers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd7e2dc9388322a8255da74789d1a4