### PR TITLE
fix: restore manual workflow trigger

### DIFF
--- a/.github/workflows/run-contact-finder.yml
+++ b/.github/workflows/run-contact-finder.yml
@@ -12,7 +12,8 @@ on:
         required: false
         default: '抹茶営業リスト（カフェ）'
   push:
-    branches: [ main ]
+    branches:
+      - main
 
 jobs:
   update:
@@ -21,7 +22,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
-        with: { python-version: '3.11' }
+        with:
+          python-version: '3.11'
 
       - run: pip install -r requirements.txt
 
@@ -31,7 +33,8 @@ jobs:
           [ -n "${{ secrets.SPREADSHEET_ID }}" ] || { echo "Missing secret: SPREADSHEET_ID"; exit 1; }
 
       - name: Write and validate service account key
-        env: { GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }} }
+        env:
+          GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
         run: |
           printf '%s' "$GOOGLE_CREDENTIALS" > sa.json
           python - <<'PY'
@@ -40,7 +43,8 @@ print('sa.json OK')
 PY
 
       - name: Update contacts on Google Sheet
-        env: { SPREADSHEET_ID: ${{ secrets.SPREADSHEET_ID }} }
+        env:
+          SPREADSHEET_ID: ${{ secrets.SPREADSHEET_ID }}
         run: |
           python update_contact_info_api.py \
             --spreadsheet-id "$SPREADSHEET_ID" \


### PR DESCRIPTION
## Summary
- ensure contact finder workflow supports manual runs and pushes to `main`
- simplify GitHub workflow configuration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd807adf108322956b85b0dc56ddd8