### PR TITLE
Fix update_contact_info command line in workflow

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,9 @@ runs:
     - name: Run update_contact_info
       shell: bash
       run: |
-        cmd="python update_contact_info.py --start-row \"${{ inputs['start-row'] }}\" --worksheet \"${{ inputs['worksheet-name'] }}\""
+        cmd="python update_contact_info.py \
+          --start-row \"${{ inputs['start-row'] }}\" \
+          --worksheet \"${{ inputs['worksheet-name'] }}\""
         if [ "${{ inputs.debug }}" = "true" ]; then
           cmd="$cmd --debug"
         fi


### PR DESCRIPTION
## Summary
- ensure `update_contact_info` workflow command uses bash line continuations so entire command is evaluated

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd828ad77c8322a8be08d0adb734df