### PR TITLE
Improve email extraction and tracking

### DIFF
--- a/email_extractors.py
+++ b/email_extractors.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+import re, json, html, urllib.parse
+from typing import Iterable, List, Set, Tuple
+from bs4 import BeautifulSoup
+
+MAILTO_RE = re.compile(r'mailto:([^"?\s>#]+)', re.I)
+PLAIN_RE = re.compile(r'\b[a-zA-Z0-9._%+\-]{1,64}@[a-zA-Z0-9.\-]{1,253}\.[A-Za-z]{2,63}\b')
+
+LABEL = r'[A-Za-z0-9\-]{1,63}'
+DOT_PAT = r'(?:\s*(?:\.|\(?.?dot\.?\)?|\[?dot\]?|\s+dot\s+)\s*)'
+AT_PAT  = r'(?:\s*(?:@|\(?.?at\.?\)?|\[?at\]?|\s+at\s+)\s*)'
+OBF_RE = re.compile(
+    rf'([A-Za-z0-9._%+\-]{{1,64}}){AT_PAT}({LABEL}(?:{DOT_PAT}{LABEL})+)',
+    re.I
+)
+
+EXTRA_CONTACT_PATHS = [
+    'contact', 'contact-us', 'about', 'about-us', 'connect', 'visit',
+    'info', 'booking', 'reservations', 'wholesale', 'order', 'orders', 'purchase', 'purchasing'
+]
+
+def decode_cfemail(hexstr: str) -> str:
+    try:
+        key = int(hexstr[:2], 16)
+        chars = [chr(int(hexstr[i:i+2], 16) ^ key) for i in range(2, len(hexstr), 2)]
+        return ''.join(chars)
+    except Exception:
+        return ''
+
+def _add(emails: Set[str], candidate: str):
+    try:
+        c = candidate.strip().strip('.,;:()[]{}<>').replace('\u200b', '')
+        c = html.unescape(c)
+        if c and '@' in c and len(c) <= 320:
+            emails.add(c)
+    except Exception:
+        pass
+
+def extract_emails_from_html(base_url: str, html_text: str) -> Set[str]:
+    emails: Set[str] = set()
+    soup = BeautifulSoup(html_text, 'html.parser')
+
+    for a in soup.find_all('a', href=True):
+        m = MAILTO_RE.search(a['href'])
+        if m:
+            _add(emails, urllib.parse.unquote(m.group(1)))
+
+    for node in soup.select('span.__cf_email__'):
+        h = node.get('data-cfemail')
+        if h:
+            addr = decode_cfemail(h)
+            if addr:
+                _add(emails, addr)
+
+    for tag in soup.find_all('script', attrs={'type': 'application/ld+json'}):
+        try:
+            data = json.loads(tag.string or 'null')
+            objs = data if isinstance(data, list) else [data]
+            for o in objs:
+                if isinstance(o, dict) and 'email' in o:
+                    e = o['email']
+                    if isinstance(e, str):
+                        _add(emails, e)
+        except Exception:
+            pass
+
+    for el in soup.find_all(attrs={'itemprop': 'email'}):
+        _add(emails, el.get_text(' ', strip=True))
+
+    for m in PLAIN_RE.finditer(html_text):
+        _add(emails, m.group(0))
+
+    for m in OBF_RE.finditer(html_text.replace('[at]', ' at ').replace('[dot]', ' dot ')):
+        local = m.group(1)
+        domain_obf = m.group(2)
+        domain = re.sub(DOT_PAT, '.', domain_obf, flags=re.I)
+        _add(emails, f'{local}@{domain}')
+
+    return emails
+
+def crawl_candidate_paths(base_url: str, fetch_html, max_pages: int = 5) -> List[Tuple[str, str]]:
+    out: List[Tuple[str, str]] = []
+    seen = set()
+    for p in EXTRA_CONTACT_PATHS:
+        if len(out) >= max_pages:
+            break
+        u = urllib.parse.urljoin(base_url, '/' + p.strip('/') + '/')
+        if u in seen:
+            continue
+        seen.add(u)
+        try:
+            html_text = fetch_html(u)
+            if html_text:
+                out.append((u, html_text))
+        except Exception:
+            continue
+    return out
+
+def score_email(addr: str) -> int:
+    a = addr.lower()
+    score = 0
+    if any(k in a for k in ['wholesale','order','orders','purchas','retail','sales','buy']):
+        score += 5
+    if any(k in a for k in ['info','contact','hello','team','office']):
+        score += 2
+    if any(k in a for k in ['careers','job','press','media','support','help','privacy','admin','noreply','no-reply','donotreply']):
+        score -= 2
+    return score
+
+def pick_best(emails: Iterable[str]) -> str | None:
+    ranked = sorted(set(emails), key=lambda e: (score_email(e), -len(e)), reverse=True)
+    return ranked[0] if ranked else None
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ google-api-python-client
 google-auth
 google-auth-httplib2
 google-auth-oauthlib
+tldextract

--- a/tests/test_email_extractors.py
+++ b/tests/test_email_extractors.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from email_extractors import decode_cfemail, extract_emails_from_html, pick_best
+
+
+def _cf_encode(addr: str, key: int = 0x12) -> str:
+    bs = bytes([key]) + bytes([ord(c) ^ key for c in addr])
+    return ''.join(f'{b:02x}' for b in bs)
+
+
+def test_cfemail_decode_roundtrip():
+    addr = 'info@thegallerypei.ca'
+    hexstr = _cf_encode(addr, 0x33)
+    assert decode_cfemail(hexstr) == addr
+
+
+def test_obfuscated_text():
+    html = 'Contact: info (at) thegallerypei (dot) ca'
+    got = extract_emails_from_html('https://example.com', html)
+    assert 'info@thegallerypei.ca' in got
+
+
+def test_jsonld_email():
+    html = """<script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"Organization","email":"hello@example.com"}
+    </script>"""
+    got = extract_emails_from_html('https://example.com', html)
+    assert 'hello@example.com' in got
+
+
+def test_pick_best_prefers_sales():
+    emails = {'info@example.com', 'wholesale@example.com'}
+    assert pick_best(emails) == 'wholesale@example.com'


### PR DESCRIPTION
## Summary
- add `email_extractors` module to decode Cloudflare-protected, JSON-LD, microdata and obfuscated emails and rank candidates
- replace API sheet email lookup with new `collect_emails` scoring flow and capture source/confidence columns
- test Cloudflare decoding, JSON-LD extraction and obfuscated text parsing

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement tldextract)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be0644a7b88322b01a675f0127fe34