### PR TITLE
Fix email extraction (Cloudflare/JSON-LD/contact pages/obfuscated text) and prevent false “なし”

### DIFF
--- a/email_extractors.py
+++ b/email_extractors.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+import re, json, html, urllib.parse
+from collections import OrderedDict
+from typing import Iterable, List, Set, Tuple, Dict
+from bs4 import BeautifulSoup
+
+MAILTO_RE = re.compile(r'mailto:([^"?\s>#]+)', re.I)
+PLAIN_RE  = re.compile(r'\b[a-zA-Z0-9._%+\-]{1,64}@[a-zA-Z0-9.\-]{1,253}\.[A-Za-z]{2,63}\b')
+
+# "name (at) domain (dot) com" 等を拾う緩めの正規表現
+LABEL = r'[A-Za-z0-9\-]{1,63}'
+DOT_PAT = r'(?:\s*(?:\.|\(?.?dot\.?\)?|\[?dot\]?|\s+dot\s+)\s*)'
+AT_PAT  = r'(?:\s*(?:@|\(?.?at\.?\)?|\[?at\]?|\s+at\s+)\s*)'
+OBF_RE = re.compile(
+    rf'([A-Za-z0-9._%+\-]{{1,64}}){AT_PAT}({LABEL}(?:{DOT_PAT}{LABEL})+)',
+    re.I
+)
+
+EXTRA_CONTACT_PATHS = [
+    'contact', 'contact-us', 'about', 'about-us', 'connect', 'visit',
+    'info', 'booking', 'reservations', 'wholesale', 'order', 'orders', 'purchase', 'purchasing'
+]
+
+def decode_cfemail(hexstr: str) -> str:
+    """Cloudflare __cf_email__ decoder."""
+    try:
+        key = int(hexstr[:2], 16)
+        chars = [chr(int(hexstr[i:i+2], 16) ^ key) for i in range(2, len(hexstr), 2)]
+        return ''.join(chars)
+    except Exception:
+        return ''
+
+
+def _add(emails: Dict[str, str], candidate: str, source: str) -> None:
+    try:
+        c = candidate.strip().strip('.,;:()[]{}<>').replace('\u200b', '')
+        c = html.unescape(c)
+        if c and '@' in c and len(c) <= 320:
+            emails.setdefault(c, source)
+    except Exception:
+        pass
+
+
+def extract_emails_from_html(base_url: str, html_text: str) -> Dict[str, str]:
+    emails: Dict[str, str] = OrderedDict()
+    soup = BeautifulSoup(html_text, 'html.parser')
+
+    # 1) mailto:
+    for a in soup.find_all('a', href=True):
+        m = MAILTO_RE.search(a['href'])
+        if m:
+            _add(emails, urllib.parse.unquote(m.group(1)), 'mailto')
+
+    # 2) Cloudflare __cf_email__
+    for node in soup.select('span.__cf_email__'):
+        h = node.get('data-cfemail')
+        if h:
+            addr = decode_cfemail(h)
+            if addr:
+                _add(emails, addr, 'cf')
+
+    # 3) JSON-LD
+    for tag in soup.find_all('script', attrs={'type': 'application/ld+json'}):
+        try:
+            data = json.loads(tag.string or 'null')
+            objs = data if isinstance(data, list) else [data]
+            for o in objs:
+                if isinstance(o, dict) and 'email' in o:
+                    e = o['email']
+                    if isinstance(e, str):
+                        _add(emails, e, 'jsonld')
+        except Exception:
+            pass
+
+    # 4) microdata
+    for el in soup.find_all(attrs={'itemprop': 'email'}):
+        _add(emails, el.get_text(' ', strip=True), 'plain')
+
+    # 5) 平文
+    for m in PLAIN_RE.finditer(html_text):
+        _add(emails, m.group(0), 'plain')
+
+    # 6) obfuscated "at/dot"
+    repl = html_text.replace('[at]', ' at ').replace('[dot]', ' dot ')
+    for m in OBF_RE.finditer(repl):
+        local = m.group(1)
+        domain_obf = m.group(2)
+        domain = re.sub(DOT_PAT, '.', domain_obf, flags=re.I)
+        _add(emails, f'{local}@{domain}', 'obf')
+
+    return emails
+
+
+def crawl_candidate_paths(base_url: str, fetch_html, max_pages: int = 5) -> List[Tuple[str, str]]:
+    """fetch_html(url)->str を受け取り、候補パスを巡回して (url, html) を返す。"""
+    out: List[Tuple[str, str]] = []
+    seen = set()
+    for p in EXTRA_CONTACT_PATHS:
+        if len(out) >= max_pages:
+            break
+        u = urllib.parse.urljoin(base_url, '/' + p.strip('/') + '/')
+        if u in seen:
+            continue
+        seen.add(u)
+        try:
+            html_text = fetch_html(u)
+            if html_text:
+                out.append((u, html_text))
+        except Exception:
+            continue
+    return out
+
+
+def score_email(addr: str) -> int:
+    a = addr.lower()
+    score = 0
+    if any(k in a for k in ['wholesale','order','orders','purchas','retail','sales','buy']):
+        score += 5
+    if any(k in a for k in ['info','contact','hello','team','office']):
+        score += 2
+    if any(k in a for k in ['careers','job','press','media','support','help','privacy','admin','noreply','no-reply','donotreply']):
+        score -= 2
+    return score
+
+
+def pick_best(emails: Iterable[str]) -> str | None:
+    ranked = sorted(set(emails), key=lambda e: (score_email(e), -len(e)), reverse=True)
+    return ranked[0] if ranked else None

--- a/tests/test_email_extractors.py
+++ b/tests/test_email_extractors.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from email_extractors import decode_cfemail, extract_emails_from_html, pick_best
+
+
+def _cf_encode(addr: str, key: int = 0x12) -> str:
+    bs = bytes([key]) + bytes([ord(c) ^ key for c in addr])
+    return ''.join(f'{b:02x}' for b in bs)
+
+
+def test_cfemail_decode_roundtrip():
+    addr = 'info@thegallerypei.ca'
+    hexstr = _cf_encode(addr, 0x33)
+    assert decode_cfemail(hexstr) == addr
+
+
+def test_obfuscated_text():
+    html = 'Contact: info (at) thegallerypei (dot) ca'
+    got = extract_emails_from_html('https://example.com', html)
+    assert 'info@thegallerypei.ca' in got
+
+
+def test_jsonld_email():
+    html = '''<script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"Organization","email":"hello@example.com"}
+    </script>'''
+    got = extract_emails_from_html('https://example.com', html)
+    assert 'hello@example.com' in got
+
+
+def test_pick_best_prefers_sales():
+    emails = {'info@example.com', 'wholesale@example.com'}
+    assert pick_best(emails) == 'wholesale@example.com'

--- a/update_contact_info_api.py
+++ b/update_contact_info_api.py
@@ -41,9 +41,54 @@ from google.oauth2 import service_account
 
 from update_contact_info import (
     find_contact_form,
-    crawl_site_for_email,
     find_instagram,
 )
+from email_extractors import (
+    extract_emails_from_html,
+    crawl_candidate_paths,
+    pick_best,
+)
+
+HDRS = {
+    "User-Agent": "Mozilla/5.0 (+https://github.com/aiup621/matcha-finder)"
+}
+
+
+def fetch_html(url: str) -> str:
+    r = requests.get(url, headers=HDRS, timeout=20)
+    r.raise_for_status()
+    return r.content.decode(errors="ignore")
+
+
+def collect_emails(url: str) -> tuple[str | None, str, str]:
+    """Return (best_email, source, confidence)."""
+    html_text = fetch_html(url)
+    emails = extract_emails_from_html(url, html_text)
+
+    if not emails:
+        for u, h in crawl_candidate_paths(url, fetch_html, max_pages=5):
+            e2 = extract_emails_from_html(u, h)
+            if e2:
+                emails.update(e2)
+                break
+
+    best = pick_best(emails.keys())
+    if best:
+        conf = (
+            "high"
+            if any(k in best.lower() for k in ["wholesale", "order", "retail", "sales", "buy", "purchas"])
+            else "mid"
+        )
+        return best, emails.get(best, "plain"), conf
+
+    parsed = urlparse(url)
+    host = parsed.hostname or ""
+    parts = host.split(".")
+    domain = ".".join(parts[-2:]) if len(parts) >= 2 else host
+    for fb in (f"info@{domain}", f"contact@{domain}"):
+        if fb:
+            return fb, "fallback", "low"
+    return None, "fallback", "low"
 
 SCOPES = ["https://www.googleapis.com/auth/spreadsheets"]
 
@@ -270,6 +315,7 @@ def process_sheet(
 
         url = row[2].strip() if len(row) > 2 and isinstance(row[2], str) else ""
         insta = email = form = ""
+        email_source = email_confidence = ""
         status = ""
 
         if not url:
@@ -283,17 +329,18 @@ def process_sheet(
             else:
                 soup = BeautifulSoup(content, "html.parser")
                 insta = find_instagram(soup, url) or ""
-                email = crawl_site_for_email(
-                    url, timeout=timeout, verify=verify_ssl
-                ) or ""
+                try:
+                    email, email_source, email_confidence = collect_emails(url)
+                except Exception:
+                    email = email_source = email_confidence = ""
                 form = find_contact_form(
                     soup, url, timeout=timeout, verify=verify_ssl
                 ) or ""
                 if not any([insta, email, form]):
                     status = "なし"
 
-        values = [[insta, email, form, status]]
-        update_range = f"{worksheet}!D{row_index}:G{row_index}"
+        values = [[insta, email, email_source, email_confidence, form, status]]
+        update_range = f"{worksheet}!D{row_index}:I{row_index}"
         (
             service.spreadsheets()
             .values()


### PR DESCRIPTION
## Summary
- decode Cloudflare `__cf_email__` hashes and parse JSON-LD, microdata, plain text and obfuscated email strings
- follow contact-like pages, score addresses and provide fallback emails with confidence and source metadata
- expand Sheet updates with email source and confidence columns

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be544d98f4832295d567212d89f0d5