### PR TITLE
Block catering email addresses

### DIFF
--- a/tests/test_update_contact_info.py
+++ b/tests/test_update_contact_info.py
@@ -460,3 +460,10 @@ def test_orders_allowed_on_trade_context():
     c = [{'email':'orders@cafe.com','source_url':'https://cafe.com/wholesale','anchor_text':'Wholesale orders'}]
     best, notes, kept, blocked = select_best_email(c, 'https://cafe.com')
     assert best == 'orders@cafe.com'
+
+
+def test_catering_blocked():
+    c = [{'email': 'catering@cafe.com', 'source_url': 'https://cafe.com', 'anchor_text': ''}]
+    best, notes, kept, blocked = select_best_email(c, 'https://cafe.com')
+    assert best is None
+    assert ('catering@cafe.com', 'blocked:purpose_mismatch') in blocked

--- a/update_contact_info_api.py
+++ b/update_contact_info_api.py
@@ -122,7 +122,7 @@ def select_best_email(candidates, site_url, allow_external=False, allow_support=
         'billing','invoice','accounting','finance',
         'legal','law','privacy','copyright','dmca','abuse','compliance','security',
         'admin','webmaster','postmaster','hostmaster',
-        'noreply','donotreply'
+        'noreply','donotreply','catering'
     )
     SUPPORT_LOCAL = ('support','helpdesk','help')
 


### PR DESCRIPTION
## Summary
- avoid using emails with local part `catering`
- test that `catering@` addresses are rejected

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68be95afb3948322bd4f35981c5a1e4f