### PR TITLE
Handle sheet download errors and block catering emails

### DIFF
--- a/tests/test_update_contact_info.py
+++ b/tests/test_update_contact_info.py
@@ -460,3 +460,20 @@ def test_orders_allowed_on_trade_context():
     c = [{'email':'orders@cafe.com','source_url':'https://cafe.com/wholesale','anchor_text':'Wholesale orders'}]
     best, notes, kept, blocked = select_best_email(c, 'https://cafe.com')
     assert best == 'orders@cafe.com'
+
+
+def test_catering_address_blocked():
+    c = [{'email':'info@mycatering.com','source_url':'https://cafe.com'}]
+    best, notes, kept, blocked = select_best_email(c, 'https://cafe.com')
+    assert best is None
+    assert any('catering' in b[1] for b in blocked)
+
+
+def test_process_sheet_download_error(monkeypatch):
+    import requests
+
+    def bad_get(url):
+        raise requests.exceptions.ConnectionError('fail')
+
+    monkeypatch.setattr(uc.requests, 'get', bad_get)
+    uc.process_sheet('http://sheet', start_row=2, worksheet='Sheet')

--- a/update_contact_info.py
+++ b/update_contact_info.py
@@ -138,8 +138,12 @@ def process_sheet(path, start_row=None, end_row=None, worksheet="抹茶営業リ
                 download_url = (
                     f"https://docs.google.com/spreadsheets/d/{file_id}/export?format=xlsx&gid={gid}"
                 )
-        resp = requests.get(download_url)
-        resp.raise_for_status()
+        try:
+            resp = requests.get(download_url)
+            resp.raise_for_status()
+        except requests.RequestException as exc:
+            logging.error("Failed to download spreadsheet %s: %s", download_url, exc)
+            return
         path = io.BytesIO(resp.content)
         save_path = "downloaded.xlsx"
 

--- a/update_contact_info_api.py
+++ b/update_contact_info_api.py
@@ -158,6 +158,9 @@ def select_best_email(candidates, site_url, allow_external=False, allow_support=
         if not email or '@' not in email:
             return None
 
+        if 'catering' in email.lower():
+            return ('blocked', email, 'blocked:catering_address')
+
         local, domain = email.split('@', 1)
         nlocal = _norm_local(local)
         path = urlparse(src).path.lower() if src else ''


### PR DESCRIPTION
## Summary
- avoid crashing when spreadsheet download fails by handling request errors
- exclude email addresses containing 'catering' from being selected
- add regression tests for download failure and catering addresses

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bea63c047483229dec98a960226a96