### PR TITLE
Skip contact finder workflow on PRs

### DIFF
--- a/.github/workflows/run-contact-finder.yml
+++ b/.github/workflows/run-contact-finder.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   update:
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Avoid running contact-finder workflow for pull_request events to prevent failures when secrets are unavailable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bea75a00bc8322ac887f6d887abb00