### PR TITLE
Exclude catering and career emails

### DIFF
--- a/tests/test_update_contact_info.py
+++ b/tests/test_update_contact_info.py
@@ -50,6 +50,31 @@ def test_crawl_site_for_email_unescapes(monkeypatch):
     assert uc.crawl_site_for_email("http://example.com") == "info@example.com"
 
 
+def test_crawl_site_for_email_skips_blocklisted(monkeypatch):
+    pages = {
+        "http://example.com": (
+            "<a href='mailto:career@example.com'>c</a>"
+            "<a href='mailto:info@example.com'>i</a>"
+        )
+    }
+
+    def fake_fetch(url, timeout=5, verify=True):
+        return pages.get(url)
+
+    monkeypatch.setattr(uc, "_fetch_page", fake_fetch)
+    assert uc.crawl_site_for_email("http://example.com") == "info@example.com"
+
+
+def test_crawl_site_for_email_returns_none_if_only_blocklisted(monkeypatch):
+    pages = {"http://example.com": "<a href='mailto:catering@example.com'>c</a>"}
+
+    def fake_fetch(url, timeout=5, verify=True):
+        return pages.get(url)
+
+    monkeypatch.setattr(uc, "_fetch_page", fake_fetch)
+    assert uc.crawl_site_for_email("http://example.com") is None
+
+
 def test_find_contact_form(monkeypatch):
     html = '<a href="/contact">contact</a>'
     soup = BeautifulSoup(html, "html.parser")


### PR DESCRIPTION
## Summary
- skip email addresses containing "catering" or "career" when crawling pages
- test crawl_site_for_email to ensure blocked addresses are ignored

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bed9583d048322bc3cf70083b21c0a