### PR TITLE
Enhance email extraction and contact crawling

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 - F列: 問い合わせフォームへのリンク
 - いずれも見つからない場合は G列に `なし` と記入
 
+メールアドレスはリンクやスクリプト、JSON-LD、`data-*` 属性、[at]/[dot] のような表記ゆれを含むテキストから抽出され、検出元 (`source`) と信頼度 (`confidence`) も記録します。
+
 GitHub Action は以下の Google スプレッドシートを対象とし、A 列が空欄の行で処理を終了します。
 https://docs.google.com/spreadsheets/d/1HU-GqN7sBcORIZrYEw4FkyfNmgDtXsO7CtDLVHEsldA/edit?gid=159511499#gid=159511499
 

--- a/collect_emails.py
+++ b/collect_emails.py
@@ -1,0 +1,114 @@
+import logging
+from collections import deque
+from typing import Optional, Dict
+from urllib.parse import urljoin, urlparse
+
+import requests
+from bs4 import BeautifulSoup
+
+from email_extractors import extract_emails, FREEMAILS
+
+SLUGS = [
+    "/contact",
+    "/contact-us",
+    "/about",
+    "/info",
+    "/visit",
+    "/find-us",
+    "/connect",
+]
+
+EMAIL_BLOCKLIST = ("catering", "career")
+
+
+def collect_emails(base_url: str, timeout: int = 5, verify: bool = True) -> Optional[Dict[str, str]]:
+    """Return the best email found on ``base_url`` or related pages."""
+
+    parsed = urlparse(base_url)
+    domain = parsed.netloc
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/120.0.0.0 Safari/537.36"
+        )
+    }
+
+    queue = deque([(base_url, 0)])
+    visited = set()
+    # enqueue slug pages
+    origin = f"{parsed.scheme}://{parsed.netloc}"
+    added = 0
+    for slug in SLUGS:
+        if added >= 3:
+            break
+        link = urljoin(origin + "/", slug.lstrip("/"))
+        if link not in visited:
+            queue.append((link, 1))
+            added += 1
+
+    candidates = []
+
+    while queue:
+        url, depth = queue.popleft()
+        if url in visited or depth > 1:
+            continue
+        visited.add(url)
+
+        try:
+            resp = requests.get(url, timeout=timeout, verify=verify, headers=headers)
+            status = resp.status_code
+            final_url = resp.url
+            content = resp.text
+            resp.raise_for_status()
+        except requests.RequestException as exc:
+            logging.info("FETCH %s error=%s", url, exc)
+            continue
+
+        soup = BeautifulSoup(content, "html.parser")
+        found = extract_emails(soup)
+        surfaces = {f["surface"] for f in found}
+        logging.info(
+            "FETCH %s status=%s final=%s bytes=%d matched=%s",
+            url,
+            status,
+            final_url,
+            len(content.encode("utf-8")),
+            ",".join(sorted(surfaces)) if surfaces else "-",
+        )
+
+        for item in found:
+            email = item["email"]
+            if any(b in email.lower() for b in EMAIL_BLOCKLIST):
+                continue
+            page_path = urlparse(final_url).path or "/"
+            candidates.append({
+                "email": email,
+                "surface": item["surface"],
+                "page": page_path,
+            })
+
+        if not found and depth < 1:
+            for a in soup.find_all("a", href=True):
+                link = urljoin(url, a["href"])
+                if urlparse(link).netloc == domain and link not in visited:
+                    queue.append((link, depth + 1))
+
+    if not candidates:
+        return None
+
+    base_domain = domain.lower()
+
+    def score(email: str) -> float:
+        dom = email.split("@", 1)[1].lower()
+        if dom.endswith(base_domain):
+            return 0.9
+        if dom in FREEMAILS:
+            return 0.5
+        return 0.7
+
+    for c in candidates:
+        c["confidence"] = score(c["email"])
+
+    best = max(candidates, key=lambda c: c["confidence"])
+    return best

--- a/email_extractors.py
+++ b/email_extractors.py
@@ -1,0 +1,132 @@
+import html
+import json
+import re
+from typing import List, Dict
+from bs4 import BeautifulSoup
+
+EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+MAILTO_RE = re.compile(
+    r"mailto:([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})",
+    re.I,
+)
+OBFUSCATED_RE = re.compile(
+    r"([A-Za-z0-9._%+-]+)[\s\[\]()\u2022\u00b7-]*@[\s\[\]()\u2022\u00b7-]*([A-Za-z0-9.-]+)[\s\[\]()\u2022\u00b7-]*\.[\s\[\]()\u2022\u00b7-]*([A-Za-z]{2,})"
+)
+
+
+FREEMAILS = {
+    "gmail.com",
+    "yahoo.com",
+    "hotmail.com",
+    "outlook.com",
+    "live.com",
+    "aol.com",
+    "icloud.com",
+    "protonmail.com",
+}
+
+
+def decode_cfemail(code: str) -> str:
+    r = int(code[:2], 16)
+    return "".join(chr(int(code[i : i + 2], 16) ^ r) for i in range(2, len(code), 2))
+
+
+def _yield_json_emails(obj):
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            if k.lower() == "email" and isinstance(v, str):
+                if EMAIL_RE.search(v):
+                    yield v
+            elif isinstance(v, (dict, list)):
+                yield from _yield_json_emails(v)
+    elif isinstance(obj, list):
+        for item in obj:
+            yield from _yield_json_emails(item)
+
+
+def extract_emails(soup: BeautifulSoup) -> List[Dict[str, str]]:
+    """Return a list of {"email", "surface"} found in ``soup``."""
+
+    results: List[Dict[str, str]] = []
+    seen = set()
+
+    # mailto links and Cloudflare protected
+    for a in soup.find_all("a", href=True):
+        href = a["href"]
+        if href.lower().startswith("mailto:"):
+            email = href.split(":", 1)[1].split("?")[0]
+            if email not in seen:
+                results.append({"email": email, "surface": "a"})
+                seen.add(email)
+        cf = a.get("data-cfemail")
+        if cf:
+            email = decode_cfemail(cf)
+            if email not in seen:
+                results.append({"email": email, "surface": "a"})
+                seen.add(email)
+
+    # inline script content
+    for tag in soup.find_all("script"):
+        if tag.string:
+            for match in MAILTO_RE.finditer(tag.string):
+                email = match.group(1)
+                if email not in seen:
+                    results.append({"email": email, "surface": "script"})
+                    seen.add(email)
+
+    # on* handlers
+    for tag in soup.find_all(True):
+        for attr, value in tag.attrs.items():
+            if attr.startswith("on") and isinstance(value, str):
+                for match in MAILTO_RE.finditer(value):
+                    email = match.group(1)
+                    if email not in seen:
+                        results.append({"email": email, "surface": "script"})
+                        seen.add(email)
+
+    # data-attribute assembly
+    for tag in soup.find_all(attrs={"data-domain": True}):
+        user = tag.get("data-user") or tag.get("data-name")
+        domain = tag.get("data-domain")
+        if user and domain:
+            email = f"{user}@{domain}"
+            if email not in seen:
+                results.append({"email": email, "surface": "data-attr"})
+                seen.add(email)
+
+    # json-ld
+    for tag in soup.find_all("script", type="application/ld+json"):
+        try:
+            data = json.loads(tag.string or "{}")
+        except json.JSONDecodeError:
+            continue
+        for email in _yield_json_emails(data):
+            if email not in seen:
+                results.append({"email": email, "surface": "jsonld"})
+                seen.add(email)
+
+    # text with obfuscation
+    raw_text = soup.get_text(" ")
+    text = html.unescape(raw_text)
+    replaced = False
+    if re.search(r"\[at\]|\(at\)|&#64;", text, flags=re.I):
+        replaced = True
+    text = re.sub(r"\[at\]|\(at\)|&#64;", "@", text, flags=re.I)
+    if re.search(r"\[dot\]|\(dot\)|&#46;", text, flags=re.I):
+        replaced = True
+    text = re.sub(r"\[dot\]|\(dot\)|&#46;", ".", text, flags=re.I)
+    text = re.sub(r"\s*@\s*", "@", text)
+    text = re.sub(r"\s*\.\s*", ".", text)
+    for match in EMAIL_RE.finditer(text):
+        email = match.group(0)
+        surface = "obfuscated" if replaced else "text"
+        if email not in seen:
+            results.append({"email": email, "surface": surface})
+            seen.add(email)
+    for match in OBFUSCATED_RE.finditer(text):
+        email = f"{match.group(1)}@{match.group(2)}.{match.group(3)}"
+        if email not in seen:
+            results.append({"email": email, "surface": "obfuscated"})
+            seen.add(email)
+
+    return results

--- a/tests/test_email_extraction.py
+++ b/tests/test_email_extraction.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import collect_emails as ce
+
+
+def _resp(url, pages):
+    class Resp:
+        def __init__(self, url):
+            self.url = url
+            self.status_code = 200
+            self.text = pages.get(url, "")
+            self.content = self.text.encode("utf-8")
+
+        def raise_for_status(self):
+            pass
+
+    return Resp(url)
+
+
+def test_js_mailto_in_script(monkeypatch):
+    pages = {"http://example.com": "<script>window.location='mailto:info@example.com'</script>"}
+
+    def fake_get(url, timeout=5, verify=True, headers=None):
+        return _resp(url, pages)
+
+    monkeypatch.setattr(ce.requests, "get", fake_get)
+    info = ce.collect_emails("http://example.com")
+    assert info["email"] == "info@example.com"
+    assert info["surface"] == "script"
+
+
+def test_data_user_domain(monkeypatch):
+    pages = {"http://example.com": '<div data-user="info" data-domain="example.com"></div>'}
+
+    def fake_get(url, timeout=5, verify=True, headers=None):
+        return _resp(url, pages)
+
+    monkeypatch.setattr(ce.requests, "get", fake_get)
+    info = ce.collect_emails("http://example.com")
+    assert info["email"] == "info@example.com"
+    assert info["surface"] == "data-attr"
+
+
+def test_obfuscated_at_dot(monkeypatch):
+    pages = {"http://example.com": "info [at] example [dot] com"}
+
+    def fake_get(url, timeout=5, verify=True, headers=None):
+        return _resp(url, pages)
+
+    monkeypatch.setattr(ce.requests, "get", fake_get)
+    info = ce.collect_emails("http://example.com")
+    assert info["email"] == "info@example.com"
+    assert info["surface"] == "obfuscated"
+
+
+def test_fallback_contact_page(monkeypatch):
+    pages = {
+        "http://example.com": "no email",
+        "http://example.com/contact": '<a href="mailto:info@example.com">c</a>',
+    }
+
+    def fake_get(url, timeout=5, verify=True, headers=None):
+        return _resp(url, pages)
+
+    monkeypatch.setattr(ce.requests, "get", fake_get)
+    info = ce.collect_emails("http://example.com")
+    assert info["email"] == "info@example.com"
+    assert info["page"] == "/contact"
+
+
+def test_onclick_mailto(monkeypatch):
+    pages = {
+        "http://example.com": "<button onclick=\"window.location='mailto:firstandlastcoffee@gmail.com'\">Email</button>"
+    }
+
+    def fake_get(url, timeout=5, verify=True, headers=None):
+        return _resp(url, pages)
+
+    monkeypatch.setattr(ce.requests, "get", fake_get)
+    info = ce.collect_emails("http://example.com")
+    assert info["email"] == "firstandlastcoffee@gmail.com"
+    assert info["surface"] == "script"

--- a/update_contact_info.py
+++ b/update_contact_info.py
@@ -1,12 +1,12 @@
 import argparse
-import html
 import logging
 import re
-from collections import deque
 from urllib.parse import urljoin, urlparse
 
 import requests
 from bs4 import BeautifulSoup
+
+from collect_emails import collect_emails
 
 EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
 REQUEST_TIMEOUT = 5
@@ -56,48 +56,10 @@ def find_instagram(soup, base_url):
 
 
 def crawl_site_for_email(base_url, max_depth=1, timeout=REQUEST_TIMEOUT, verify=True):
-    """Crawl ``base_url`` breadth-first looking for an email address."""
+    """Crawl ``base_url`` looking for an email address."""
 
-    parsed = urlparse(base_url)
-    domain = parsed.netloc
-    queue = deque([(base_url, 0)])
-    visited = set()
-
-    while queue:
-        url, depth = queue.popleft()
-        if url in visited or depth > max_depth:
-            continue
-        visited.add(url)
-
-        content = _fetch_page(url, timeout=timeout, verify=verify)
-        if not content:
-            continue
-
-        soup = BeautifulSoup(content, "html.parser")
-
-        mailtos = soup.find_all("a", href=lambda h: h and h.lower().startswith("mailto:"))
-        for m in mailtos:
-            href = m["href"]
-            candidate = re.sub(r"^mailto:", "", href, flags=re.I).split("?")[0]
-            if any(b in candidate.lower() for b in EMAIL_BLOCKLIST):
-                continue
-            return candidate
-
-        text = html.unescape(soup.get_text(" "))
-        for pattern in ["[at]", "(at)", "＠"]:
-            text = text.replace(pattern, "@")
-        for match in EMAIL_RE.finditer(text):
-            candidate = match.group(0)
-            if any(b in candidate.lower() for b in EMAIL_BLOCKLIST):
-                continue
-            return candidate
-
-        if depth < max_depth:
-            for a in soup.find_all("a", href=True):
-                link = urljoin(url, a["href"])
-                if urlparse(link).netloc == domain and link not in visited:
-                    queue.append((link, depth + 1))
-    return None
+    info = collect_emails(base_url, timeout=timeout, verify=verify)
+    return info["email"] if info else None
 
 
 def find_contact_form(soup, base_url, timeout=REQUEST_TIMEOUT, verify=True):


### PR DESCRIPTION
## Summary
- Expand email extraction to scan scripts, JSON-LD, data-* attributes and obfuscated text while tracking the source surface
- Crawl common contact pages and score domain vs. freemail addresses with logging for each fetch
- Expose the new collection flow in `crawl_site_for_email` and document surface and confidence details

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bedcf74f4483228ab6ad19c368adaf