### PR TITLE
Delete rows with duplicate emails or errors

### DIFF
--- a/tests/test_update_contact_info.py
+++ b/tests/test_update_contact_info.py
@@ -471,7 +471,49 @@ def test_request_failure_marks_error(tmp_path, monkeypatch):
 
     wb2 = openpyxl.load_workbook(file)
     ws2 = wb2["Sheet"]
-    assert ws2.cell(row=2, column=7).value == "エラー"
+    assert ws2.max_row == 1
+
+
+def test_duplicate_emails_are_removed(tmp_path, monkeypatch):
+    import openpyxl
+
+    class DummyResponse:
+        def __init__(self, text):
+            self.text = text
+            self.status_code = 200
+
+        def raise_for_status(self):
+            pass
+
+    pages = {
+        "http://a": "<a href='mailto:info@example.com'>mail</a>",
+        "http://b": "<a href='mailto:INFO@example.com'>mail</a>",
+    }
+
+    def dummy_get(url, timeout, verify=True, headers=None):
+        return DummyResponse(pages.get(url, "<html></html>"))
+
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "Sheet"
+    ws.cell(row=2, column=1, value="ok")
+    ws.cell(row=2, column=3, value="http://a")
+    ws.cell(row=3, column=1, value="ok")
+    ws.cell(row=3, column=3, value="http://b")
+    file = tmp_path / "sample.xlsx"
+    wb.save(file)
+
+    monkeypatch.setattr(uc.requests, "get", dummy_get)
+    uc.process_sheet(str(file), start_row=2, end_row=3, worksheet="Sheet")
+
+    wb2 = openpyxl.load_workbook(file)
+    ws2 = wb2["Sheet"]
+    emails = [
+        ws2.cell(row=row, column=5).value
+        for row in range(2, ws2.max_row + 1)
+        if ws2.cell(row=row, column=5).value
+    ]
+    assert emails == ["info@example.com"]
 
 
 def test_orders_blocked_on_consumer_context():


### PR DESCRIPTION
## Summary
- add helpers that normalize email values and identify rows that should be deleted
- after updating contact info, delete any rows whose email duplicates a previous one or whose status is エラー
- adjust the request failure test and add a new test that verifies duplicate rows are removed

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0827a244083229c0bec870534ed96